### PR TITLE
fix: プロダクションビルドの白画面問題を修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ const host = process.env.TAURI_DEV_HOST;
 export default defineConfig(async () => ({
   plugins: [react(), tailwindcss()],
   clearScreen: false,
+  base: "./",
   server: {
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
## Summary
- Viteの`base`オプションを`"./"`に設定し、Tauriのfile://プロトコルでアセットが正しく読み込まれるようにした
- この修正により、ビルド済みAppImage/DMG/MSI起動時の白画面問題が解消される

## Root Cause
Viteのデフォルト`base: "/"`では、ビルド後のアセットパスが`/assets/index-xxx.js`のような絶対パスになる。Tauriはプロダクションでは`file://`プロトコルを使うため、`file:///assets/...`を探しに行き、アセットが見つからず白画面になっていた。

## Test plan
- [ ] `bun tauri build`でビルド後、AppImageを実行して画面が表示されることを確認
- [ ] macOS DMGでも同様に確認
- [ ] Windows MSI/NSISインストーラーでも同様に確認

Generated with [Claude Code](https://claude.com/claude-code)