### PR TITLE
ファイルダブルクリックでデフォルトアプリ起動

### DIFF
--- a/src/commands/fs-commands.test.ts
+++ b/src/commands/fs-commands.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openPath: vi.fn(),
+}));
+
+import { openFile } from "./fs-commands";
+import { openPath } from "@tauri-apps/plugin-opener";
+
+const mockOpenPath = vi.mocked(openPath);
+
+describe("openFile", () => {
+  it("openPath を呼び出す", async () => {
+    mockOpenPath.mockResolvedValue(undefined);
+    await openFile("/home/user/document.pdf");
+    expect(mockOpenPath).toHaveBeenCalledWith("/home/user/document.pdf");
+  });
+
+  it("openPath のエラーをそのまま投げる", async () => {
+    mockOpenPath.mockRejectedValue(new Error("failed to open"));
+    await expect(openFile("/bad/path")).rejects.toThrow("failed to open");
+  });
+});

--- a/src/commands/fs-commands.ts
+++ b/src/commands/fs-commands.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { openPath } from "@tauri-apps/plugin-opener";
 import type { FileEntry } from "../types";
 
 export async function readDirectory(path: string): Promise<FileEntry[]> {
@@ -54,4 +55,8 @@ export async function readFilePreview(
   maxBytes?: number
 ): Promise<string> {
   return invoke<string>("read_file_preview", { path, maxBytes });
+}
+
+export async function openFile(path: string): Promise<void> {
+  return openPath(path);
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -12,6 +12,7 @@ import {
   deleteItems,
   copyItems,
   moveItems,
+  openFile,
 } from "../commands/fs-commands";
 import { useKeyboardShortcuts } from "../hooks/use-keyboard-shortcuts";
 import { TabBar } from "./TabBar";
@@ -145,7 +146,7 @@ export function AppLayout() {
       if (entry.isDir) {
         navigateTo(entry.path);
       } else {
-        setPreviewEntry(entry);
+        openFile(entry.path).catch(console.error);
       }
     },
     [navigateTo]
@@ -164,6 +165,14 @@ export function AppLayout() {
               const entry = getSelectedEntry();
               if (entry) handleFileOpen(entry);
             },
+          },
+        ]
+      : []),
+    ...(selectedEntry && !selectedEntry.isDir
+      ? [
+          {
+            label: "Preview",
+            onClick: () => setPreviewEntry(selectedEntry),
           },
         ]
       : []),


### PR DESCRIPTION
## Summary

- ファイルをダブルクリックするとOSのデフォルトアプリケーションで開くように変更
- `@tauri-apps/plugin-opener` の `openPath` を使用（プラグインは既にインストール・登録済み）
- コンテキストメニューに「Preview」項目を追加（テキスト/画像プレビューは引き続き利用可能）

## Changes

- `src/commands/fs-commands.ts`: `openFile()` 関数追加
- `src/components/AppLayout.tsx`: `handleFileOpen` をデフォルトアプリ起動に変更、コンテキストメニューにPreview追加
- `src/commands/fs-commands.test.ts`: `openFile` のユニットテスト追加

## Test plan

- [x] `bun run test` -- 74 tests passing
- [ ] ファイルをダブルクリック → デフォルトアプリで開くことを確認
- [ ] ディレクトリのダブルクリック → ナビゲーション（既存動作に変更なし）
- [ ] コンテキストメニュー > Preview → プレビューダイアログが開く

closes #7

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>