### PR TITLE
v0.1.1 にバージョンアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-filer",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Cross-platform desktop file manager built with Tauri 2 + React 19",
   "author": "win-chanma",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-filer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-filer"
-version = "0.1.0"
+version = "0.1.1"
 description = "Desktop File Manager"
 authors = ["win-chanma"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tauri Filer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.win.tauri-filer",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- package.json, Cargo.toml, tauri.conf.json のバージョンを 0.1.0 → 0.1.1 に更新
- 初回公式リリース v0.1.1 の準備

## Test plan
- [x] `bun run test` - フロントエンド 74テスト全パス
- [x] `cargo test` - バックエンド 29テスト全パス

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)