### PR TITLE
Windows隠しファイル検出 + 視覚的スタイリング

### DIFF
--- a/src/components/FileCard.test.tsx
+++ b/src/components/FileCard.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FileCard } from "./FileCard";
+import type { FileEntry } from "../types";
+
+function makeEntry(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    name: "test.txt",
+    path: "/test.txt",
+    isDir: false,
+    isSymlink: false,
+    isHidden: false,
+    size: 100,
+    modified: "2026-01-01 00:00",
+    mimeType: "text/plain",
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+const defaultProps = {
+  selected: false,
+  onSelect: noop as unknown as (e: React.MouseEvent) => void,
+  onOpen: noop,
+};
+
+describe("FileCard opacity", () => {
+  it("does not apply opacity class for normal file", () => {
+    render(<FileCard entry={makeEntry()} isCut={false} {...defaultProps} />);
+    const card = screen.getByText("test.txt").closest("[class*='flex']")!;
+    expect(card.className).not.toMatch(/opacity-/);
+  });
+
+  it("applies opacity-[0.55] for hidden file", () => {
+    render(
+      <FileCard
+        entry={makeEntry({ isHidden: true, name: ".hidden" })}
+        isCut={false}
+        {...defaultProps}
+      />
+    );
+    const card = screen.getByText(".hidden").closest("[class*='flex']")!;
+    expect(card.className).toContain("opacity-[0.55]");
+  });
+
+  it("applies opacity-[0.4] for cut file", () => {
+    render(<FileCard entry={makeEntry()} isCut={true} {...defaultProps} />);
+    const card = screen.getByText("test.txt").closest("[class*='flex']")!;
+    expect(card.className).toContain("opacity-[0.4]");
+  });
+
+  it("applies opacity-[0.22] for hidden + cut file", () => {
+    render(
+      <FileCard
+        entry={makeEntry({ isHidden: true, name: ".hidden" })}
+        isCut={true}
+        {...defaultProps}
+      />
+    );
+    const card = screen.getByText(".hidden").closest("[class*='flex']")!;
+    expect(card.className).toContain("opacity-[0.22]");
+  });
+});

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -1,22 +1,26 @@
 import { memo } from "react";
 import type { FileEntry } from "../types";
 import { FileIcon } from "./FileIcon";
+import { getFileOpacity } from "../utils/file-opacity";
 
 interface FileCardProps {
   entry: FileEntry;
   selected: boolean;
+  isCut: boolean;
   onSelect: (e: React.MouseEvent) => void;
   onOpen: () => void;
 }
 
-export const FileCard = memo(function FileCard({ entry, selected, onSelect, onOpen }: FileCardProps) {
+export const FileCard = memo(function FileCard({ entry, selected, isCut, onSelect, onOpen }: FileCardProps) {
+  const opacityClass = getFileOpacity({ isHidden: entry.isHidden, isCut });
+
   return (
     <div
       className={`flex flex-col items-center gap-1.5 p-3 rounded-lg cursor-pointer select-none ${
         selected
           ? "bg-indigo-500/20 ring-1 ring-indigo-500/50"
           : "hover:bg-white/5"
-      }`}
+      }${opacityClass ? ` ${opacityClass}` : ""}`}
       onClick={onSelect}
       onDoubleClick={onOpen}
     >

--- a/src/components/FileRow.test.tsx
+++ b/src/components/FileRow.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FileRow } from "./FileRow";
+import type { FileEntry } from "../types";
+
+function makeEntry(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    name: "test.txt",
+    path: "/test.txt",
+    isDir: false,
+    isSymlink: false,
+    isHidden: false,
+    size: 100,
+    modified: "2026-01-01 00:00",
+    mimeType: "text/plain",
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+const defaultProps = {
+  selected: false,
+  onSelect: noop as unknown as (e: React.MouseEvent) => void,
+  onOpen: noop,
+};
+
+describe("FileRow opacity", () => {
+  it("does not apply opacity class for normal file", () => {
+    render(<FileRow entry={makeEntry()} isCut={false} {...defaultProps} />);
+    const row = screen.getByText("test.txt").closest("[class*='grid']")!;
+    expect(row.className).not.toMatch(/opacity-/);
+  });
+
+  it("applies opacity-[0.55] for hidden file", () => {
+    render(
+      <FileRow
+        entry={makeEntry({ isHidden: true, name: ".hidden" })}
+        isCut={false}
+        {...defaultProps}
+      />
+    );
+    const row = screen.getByText(".hidden").closest("[class*='grid']")!;
+    expect(row.className).toContain("opacity-[0.55]");
+  });
+
+  it("applies opacity-[0.4] for cut file", () => {
+    render(<FileRow entry={makeEntry()} isCut={true} {...defaultProps} />);
+    const row = screen.getByText("test.txt").closest("[class*='grid']")!;
+    expect(row.className).toContain("opacity-[0.4]");
+  });
+
+  it("applies opacity-[0.22] for hidden + cut file", () => {
+    render(
+      <FileRow
+        entry={makeEntry({ isHidden: true, name: ".hidden" })}
+        isCut={true}
+        {...defaultProps}
+      />
+    );
+    const row = screen.getByText(".hidden").closest("[class*='grid']")!;
+    expect(row.className).toContain("opacity-[0.22]");
+  });
+});

--- a/src/components/FileRow.tsx
+++ b/src/components/FileRow.tsx
@@ -2,10 +2,12 @@ import { memo, useState } from "react";
 import type { FileEntry } from "../types";
 import { FileIcon } from "./FileIcon";
 import { formatFileSize, formatDate } from "../utils/format";
+import { getFileOpacity } from "../utils/file-opacity";
 
 interface FileRowProps {
   entry: FileEntry;
   selected: boolean;
+  isCut: boolean;
   onSelect: (e: React.MouseEvent) => void;
   onOpen: () => void;
   onContextMenu?: (e: React.MouseEvent) => void;
@@ -17,6 +19,7 @@ interface FileRowProps {
 export const FileRow = memo(function FileRow({
   entry,
   selected,
+  isCut,
   onSelect,
   onOpen,
   onContextMenu,
@@ -25,6 +28,7 @@ export const FileRow = memo(function FileRow({
   onDrop,
 }: FileRowProps) {
   const [dropTarget, setDropTarget] = useState(false);
+  const opacityClass = getFileOpacity({ isHidden: entry.isHidden, isCut });
 
   return (
     <div
@@ -34,7 +38,7 @@ export const FileRow = memo(function FileRow({
           : selected
             ? "bg-indigo-500/20 text-slate-100"
             : "text-slate-400 hover:bg-white/5"
-      }`}
+      }${opacityClass ? ` ${opacityClass}` : ""}`}
       onClick={onSelect}
       onDoubleClick={onOpen}
       onContextMenu={(e) => {

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -2,8 +2,10 @@ import { useMemo, useCallback } from "react";
 import { VirtuosoGrid } from "react-virtuoso";
 import { useFileStore } from "../stores/file-store";
 import { useUIStore } from "../stores/ui-store";
+import { useClipboardStore } from "../stores/clipboard-store";
 import { useNavigation } from "../hooks/use-navigation";
 import { sortEntries } from "../utils/sort";
+import { isCutPath } from "../utils/clipboard-helpers";
 import { FileCard } from "./FileCard";
 import type { FileEntry } from "../types";
 
@@ -19,6 +21,8 @@ export function GridView({ onContextMenu, onFileOpen }: GridViewProps) {
   const selectedPaths = useFileStore((s) => s.selectedPaths);
   const setSelectedPaths = useFileStore((s) => s.setSelectedPaths);
   const toggleSelection = useFileStore((s) => s.toggleSelection);
+  const clipboardPaths = useClipboardStore((s) => s.paths);
+  const clipboardMode = useClipboardStore((s) => s.mode);
   const { navigateTo } = useNavigation();
 
   const sortedEntries = useMemo(
@@ -58,11 +62,12 @@ export function GridView({ onContextMenu, onFileOpen }: GridViewProps) {
       <FileCard
         entry={entry}
         selected={selectedPaths.has(entry.path)}
+        isCut={isCutPath(entry.path, clipboardPaths, clipboardMode)}
         onSelect={(e) => handleSelect(entry, e)}
         onOpen={() => handleOpen(entry)}
       />
     ),
-    [selectedPaths, handleSelect, handleOpen]
+    [selectedPaths, clipboardPaths, clipboardMode, handleSelect, handleOpen]
   );
 
   return (

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -3,9 +3,11 @@ import { Virtuoso } from "react-virtuoso";
 import { useFileStore } from "../stores/file-store";
 import { useUIStore } from "../stores/ui-store";
 import { useTabStore } from "../stores/tab-store";
+import { useClipboardStore } from "../stores/clipboard-store";
 import { useDragDrop } from "../hooks/use-drag-drop";
 import { useNavigation } from "../hooks/use-navigation";
 import { sortEntries } from "../utils/sort";
+import { isCutPath } from "../utils/clipboard-helpers";
 import { FileRow } from "./FileRow";
 import type { FileEntry, SortKey } from "../types";
 import { ArrowUp, ArrowDown } from "lucide-react";
@@ -31,6 +33,8 @@ export function ListView({ onContextMenu, onFileOpen }: ListViewProps) {
   const setSortConfig = useFileStore((s) => s.setSortConfig);
   const loadDirectory = useFileStore((s) => s.loadDirectory);
   const { navigateTo } = useNavigation();
+  const clipboardPaths = useClipboardStore((s) => s.paths);
+  const clipboardMode = useClipboardStore((s) => s.mode);
   const { handleDragStart, handleDragOver, handleDrop } = useDragDrop();
 
   const sortedEntries = useMemo(
@@ -84,6 +88,7 @@ export function ListView({ onContextMenu, onFileOpen }: ListViewProps) {
       <FileRow
         entry={entry}
         selected={selectedPaths.has(entry.path)}
+        isCut={isCutPath(entry.path, clipboardPaths, clipboardMode)}
         onSelect={(e) => handleSelect(entry, e)}
         onOpen={() => handleOpen(entry)}
         onContextMenu={onContextMenu}
@@ -99,7 +104,7 @@ export function ListView({ onContextMenu, onFileOpen }: ListViewProps) {
         }}
       />
     ),
-    [selectedPaths, handleSelect, handleOpen, onContextMenu, handleDragStart, handleDragOver, handleDrop, loadDirectory]
+    [selectedPaths, clipboardPaths, clipboardMode, handleSelect, handleOpen, onContextMenu, handleDragStart, handleDragOver, handleDrop, loadDirectory]
   );
 
   return (

--- a/src/utils/clipboard-helpers.test.ts
+++ b/src/utils/clipboard-helpers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isCutPath } from "./clipboard-helpers";
+
+describe("isCutPath", () => {
+  it("returns false when mode is null", () => {
+    expect(isCutPath("/a.txt", ["/a.txt"], null)).toBe(false);
+  });
+
+  it("returns false when mode is copy", () => {
+    expect(isCutPath("/a.txt", ["/a.txt"], "copy")).toBe(false);
+  });
+
+  it("returns false when mode is cut but path does not match", () => {
+    expect(isCutPath("/a.txt", ["/b.txt"], "cut")).toBe(false);
+  });
+
+  it("returns true when mode is cut and path matches", () => {
+    expect(isCutPath("/a.txt", ["/a.txt", "/b.txt"], "cut")).toBe(true);
+  });
+});

--- a/src/utils/clipboard-helpers.ts
+++ b/src/utils/clipboard-helpers.ts
@@ -1,0 +1,9 @@
+type ClipboardMode = "copy" | "cut" | null;
+
+export function isCutPath(
+  filePath: string,
+  clipboardPaths: string[],
+  clipboardMode: ClipboardMode
+): boolean {
+  return clipboardMode === "cut" && clipboardPaths.includes(filePath);
+}

--- a/src/utils/file-opacity.test.ts
+++ b/src/utils/file-opacity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getFileOpacity } from "./file-opacity";
+
+describe("getFileOpacity", () => {
+  it("returns undefined for normal file", () => {
+    expect(getFileOpacity({ isHidden: false, isCut: false })).toBeUndefined();
+  });
+
+  it("returns opacity-[0.55] for hidden file", () => {
+    expect(getFileOpacity({ isHidden: true, isCut: false })).toBe(
+      "opacity-[0.55]"
+    );
+  });
+
+  it("returns opacity-[0.4] for cut file", () => {
+    expect(getFileOpacity({ isHidden: false, isCut: true })).toBe(
+      "opacity-[0.4]"
+    );
+  });
+
+  it("returns opacity-[0.22] for hidden + cut file", () => {
+    expect(getFileOpacity({ isHidden: true, isCut: true })).toBe(
+      "opacity-[0.22]"
+    );
+  });
+});

--- a/src/utils/file-opacity.ts
+++ b/src/utils/file-opacity.ts
@@ -1,0 +1,15 @@
+export const FILE_OPACITY = { hidden: 0.55, cut: 0.4 } as const;
+
+export function getFileOpacity({
+  isHidden,
+  isCut,
+}: {
+  isHidden: boolean;
+  isCut: boolean;
+}): string | undefined {
+  if (!isHidden && !isCut) return undefined;
+  let opacity = 1;
+  if (isHidden) opacity *= FILE_OPACITY.hidden;
+  if (isCut) opacity *= FILE_OPACITY.cut;
+  return `opacity-[${Math.round(opacity * 100) / 100}]`;
+}


### PR DESCRIPTION
## Summary
- Rust側に`is_hidden_file()`を追加し、WindowsのFILE_ATTRIBUTE_HIDDEN属性を検出
- 隠しファイル(opacity 0.55)、カットファイル(opacity 0.4)、隠し+カット(opacity 0.22)の透過度スタイリングを導入
- FileRow/FileCardに`isCut` propを追加し、ListView/GridViewからclipboard storeを購読して伝播

## Test plan
- [x] Rust: `is_hidden_file()`のユニットテスト追加（dot prefix検出、通常ファイル非検出）
- [x] Frontend: `getFileOpacity()`の4パターンテスト
- [x] Frontend: `isCutPath()`の4パターンテスト
- [x] Frontend: FileRow/FileCardの opacity適用テスト（各4パターン）
- [x] 型チェック通過 (`tsc --noEmit`)
- [x] 全テスト通過（Rust 31件、Frontend 90件）

closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)