### PR TITLE
feat: 設定画面 (SettingsDialog) の追加と UIStore の永続化

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -27,6 +27,7 @@ import { RenameDialog } from "./RenameDialog";
 import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
 import { SearchDialog } from "./SearchDialog";
 import { FilePreviewDialog } from "./FilePreviewDialog";
+import { SettingsDialog } from "./SettingsDialog";
 import { EmptyState } from "./EmptyState";
 import { Spinner } from "./Spinner";
 import type { FileEntry } from "../types";
@@ -55,6 +56,7 @@ export function AppLayout() {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [previewEntry, setPreviewEntry] = useState<FileEntry | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const { menu, show: showContextMenu, hide: hideContextMenu } = useContextMenu();
 
@@ -206,7 +208,7 @@ export function AppLayout() {
   return (
     <div className="flex flex-col h-screen bg-[#0a0a0f] text-slate-200">
       <TabBar />
-      <Toolbar />
+      <Toolbar onSettingsOpen={() => setSettingsOpen(true)} />
       <div className="flex flex-1 min-h-0">
         {sidebarVisible && <Sidebar />}
         <main className="flex-1 min-w-0 flex flex-col">
@@ -258,6 +260,10 @@ export function AppLayout() {
         open={!!previewEntry}
         entry={previewEntry}
         onClose={() => setPreviewEntry(null)}
+      />
+      <SettingsDialog
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
       />
     </div>
   );

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SettingsDialog } from "./SettingsDialog";
+import { useUIStore } from "../stores/ui-store";
+
+describe("SettingsDialog", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    onClose.mockClear();
+    useUIStore.setState({
+      viewMode: "list",
+      sidebarVisible: true,
+      showHidden: false,
+    });
+  });
+
+  it("open=falseで何もレンダリングされない", () => {
+    const { container } = render(
+      <SettingsDialog open={false} onClose={onClose} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("open=trueでダイアログが表示される", () => {
+    render(<SettingsDialog open={true} onClose={onClose} />);
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("隠しファイルトグルが動作する", () => {
+    render(<SettingsDialog open={true} onClose={onClose} />);
+    const toggle = screen.getByRole("switch", { name: /hidden/i });
+    expect(toggle).not.toBeChecked();
+    fireEvent.click(toggle);
+    expect(useUIStore.getState().showHidden).toBe(true);
+  });
+
+  it("サイドバートグルが動作する", () => {
+    render(<SettingsDialog open={true} onClose={onClose} />);
+    const toggle = screen.getByRole("switch", { name: /sidebar/i });
+    expect(toggle).toBeChecked();
+    fireEvent.click(toggle);
+    expect(useUIStore.getState().sidebarVisible).toBe(false);
+  });
+
+  it("ビューモード切替が動作する", () => {
+    render(<SettingsDialog open={true} onClose={onClose} />);
+    const gridBtn = screen.getByRole("radio", { name: /grid/i });
+    fireEvent.click(gridBtn);
+    expect(useUIStore.getState().viewMode).toBe("grid");
+  });
+
+  it("閉じるボタンでonCloseが呼ばれる", () => {
+    render(<SettingsDialog open={true} onClose={onClose} />);
+    const closeBtn = screen.getByTitle("Close");
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("オーバーレイクリックでonCloseが呼ばれる", () => {
+    render(<SettingsDialog open={true} onClose={onClose} />);
+    const overlay = screen.getByTestId("settings-overlay");
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,0 +1,177 @@
+import { useUIStore } from "../stores/ui-store";
+import { X, List, LayoutGrid } from "lucide-react";
+
+interface SettingsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
+  const viewMode = useUIStore((s) => s.viewMode);
+  const setViewMode = useUIStore((s) => s.setViewMode);
+  const sidebarVisible = useUIStore((s) => s.sidebarVisible);
+  const toggleSidebar = useUIStore((s) => s.toggleSidebar);
+  const showHidden = useUIStore((s) => s.showHidden);
+  const toggleHidden = useUIStore((s) => s.toggleHidden);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      data-testid="settings-overlay"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-xl w-[520px] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between h-14 px-6 border-b border-[var(--color-border)]">
+          <h2 className="text-base font-semibold text-[var(--color-text)]">Settings</h2>
+          <button
+            className="p-2 -mr-2 rounded-lg text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            onClick={onClose}
+            title="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6">
+          <h3 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-widest mb-3">
+            表示
+          </h3>
+
+          <div className="rounded-lg border border-[var(--color-border)] overflow-hidden divide-y divide-[var(--color-border)]">
+            <SettingRow
+              label="隠しファイルを表示"
+              description="ドットで始まるファイルやフォルダを表示します"
+            >
+              <ToggleSwitch
+                checked={showHidden}
+                onChange={toggleHidden}
+                aria-label="Show hidden files"
+              />
+            </SettingRow>
+
+            <SettingRow
+              label="サイドバー"
+              description="ナビゲーション用のサイドバーを表示します"
+            >
+              <ToggleSwitch
+                checked={sidebarVisible}
+                onChange={toggleSidebar}
+                aria-label="Sidebar visible"
+              />
+            </SettingRow>
+
+            <SettingRow
+              label="表示モード"
+              description="ファイル一覧の表示方法を切り替えます"
+            >
+              <div
+                className="flex rounded-lg overflow-hidden border border-[var(--color-border)]"
+                role="radiogroup"
+              >
+                <ViewModeButton
+                  label="List"
+                  icon={<List size={14} />}
+                  active={viewMode === "list"}
+                  onClick={() => setViewMode("list")}
+                />
+                <div className="w-px bg-[var(--color-border)]" />
+                <ViewModeButton
+                  label="Grid"
+                  icon={<LayoutGrid size={14} />}
+                  active={viewMode === "grid"}
+                  onClick={() => setViewMode("grid")}
+                />
+              </div>
+            </SettingRow>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SettingRow({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between min-h-[64px] px-5 py-4 bg-[var(--color-bg)]/30">
+      <div className="flex flex-col gap-1 min-w-0 mr-6">
+        <span className="text-sm font-medium text-[var(--color-text)]">{label}</span>
+        {description && (
+          <span className="text-xs text-[var(--color-text-muted)] leading-relaxed">{description}</span>
+        )}
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  );
+}
+
+function ToggleSwitch({
+  checked,
+  onChange,
+  "aria-label": ariaLabel,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  "aria-label": string;
+}) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={onChange}
+      className={`relative w-12 h-7 rounded-full p-[3px] transition-colors duration-200 ${
+        checked ? "bg-[var(--color-accent)]" : "bg-[var(--color-text-muted)]/40"
+      }`}
+    >
+      <span
+        className={`block w-[22px] h-[22px] rounded-full bg-white shadow transition-transform duration-200 ${
+          checked ? "translate-x-[21px]" : "translate-x-0"
+        }`}
+      />
+    </button>
+  );
+}
+
+function ViewModeButton({
+  label,
+  icon,
+  active,
+  onClick,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      role="radio"
+      aria-checked={active}
+      aria-label={label}
+      onClick={onClick}
+      className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors duration-150 ${
+        active
+          ? "bg-[var(--color-accent)] text-white"
+          : "bg-[var(--color-bg)] text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -13,9 +13,14 @@ import {
   PanelLeft,
   Eye,
   EyeOff,
+  Settings,
 } from "lucide-react";
 
-export function Toolbar() {
+interface ToolbarProps {
+  onSettingsOpen?: () => void;
+}
+
+export function Toolbar({ onSettingsOpen }: ToolbarProps) {
   const canGoBack = useTabStore((s) => s.canGoBack);
   const canGoForward = useTabStore((s) => s.canGoForward);
   const viewMode = useUIStore((s) => s.viewMode);
@@ -27,42 +32,53 @@ export function Toolbar() {
   const { back, forward, up, refresh } = useNavigation();
 
   return (
-    <div className="flex items-center gap-1 px-2 py-1.5 border-b border-[#2a2a3a]">
-      <NavButton onClick={toggleSidebar} title="Toggle sidebar">
-        {sidebarVisible ? <PanelLeftClose size={16} /> : <PanelLeft size={16} />}
-      </NavButton>
-      <NavButton onClick={back} disabled={!canGoBack()} title="Back">
-        <ArrowLeft size={16} />
-      </NavButton>
-      <NavButton onClick={forward} disabled={!canGoForward()} title="Forward">
-        <ArrowRight size={16} />
-      </NavButton>
-      <NavButton onClick={up} title="Parent directory">
-        <ArrowUp size={16} />
-      </NavButton>
-      <NavButton onClick={refresh} title="Refresh">
-        <RefreshCw size={16} />
-      </NavButton>
+    <div className="flex items-center gap-2 px-4 h-12 border-b border-[var(--color-border)]">
+      {/* Navigation group */}
+      <div className="flex items-center gap-1">
+        <NavButton onClick={toggleSidebar} title="Toggle sidebar">
+          {sidebarVisible ? <PanelLeftClose size={18} /> : <PanelLeft size={18} />}
+        </NavButton>
+        <NavButton onClick={back} disabled={!canGoBack()} title="Back">
+          <ArrowLeft size={18} />
+        </NavButton>
+        <NavButton onClick={forward} disabled={!canGoForward()} title="Forward">
+          <ArrowRight size={18} />
+        </NavButton>
+        <NavButton onClick={up} title="Parent directory">
+          <ArrowUp size={18} />
+        </NavButton>
+        <NavButton onClick={refresh} title="Refresh">
+          <RefreshCw size={18} />
+        </NavButton>
+      </div>
 
       <AddressBar />
 
-      <NavButton onClick={toggleHidden} title="Toggle hidden files">
-        {showHidden ? <Eye size={16} /> : <EyeOff size={16} />}
-      </NavButton>
-      <NavButton
-        onClick={() => setViewMode("list")}
-        active={viewMode === "list"}
-        title="List view"
-      >
-        <List size={16} />
-      </NavButton>
-      <NavButton
-        onClick={() => setViewMode("grid")}
-        active={viewMode === "grid"}
-        title="Grid view"
-      >
-        <LayoutGrid size={16} />
-      </NavButton>
+      {/* Action group */}
+      <div className="flex items-center gap-1">
+        {onSettingsOpen && (
+          <NavButton onClick={onSettingsOpen} title="Settings">
+            <Settings size={18} />
+          </NavButton>
+        )}
+        <NavButton onClick={toggleHidden} title="Toggle hidden files">
+          {showHidden ? <Eye size={18} /> : <EyeOff size={18} />}
+        </NavButton>
+        <NavButton
+          onClick={() => setViewMode("list")}
+          active={viewMode === "list"}
+          title="List view"
+        >
+          <List size={18} />
+        </NavButton>
+        <NavButton
+          onClick={() => setViewMode("grid")}
+          active={viewMode === "grid"}
+          title="Grid view"
+        >
+          <LayoutGrid size={18} />
+        </NavButton>
+      </div>
     </div>
   );
 }
@@ -82,8 +98,10 @@ function NavButton({
 }) {
   return (
     <button
-      className={`p-1.5 rounded hover:bg-white/10 disabled:opacity-30 disabled:cursor-not-allowed ${
-        active ? "text-indigo-400 bg-indigo-500/10" : "text-slate-400 hover:text-slate-200"
+      className={`p-2 rounded-lg hover:bg-[var(--color-bg-hover)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors ${
+        active
+          ? "text-[var(--color-accent-light)] bg-[var(--color-accent)]/10"
+          : "text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
       }`}
       onClick={onClick}
       disabled={disabled}

--- a/src/stores/ui-store.test.ts
+++ b/src/stores/ui-store.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useUIStore } from "./ui-store";
+import { useUIStore, loadSettings } from "./ui-store";
+
+const STORAGE_KEY = "tauri-filer-ui-settings";
 
 describe("uiStore", () => {
   beforeEach(() => {
+    localStorage.clear();
     useUIStore.setState({
       viewMode: "list",
       sidebarVisible: true,
@@ -53,6 +56,50 @@ describe("uiStore", () => {
       useUIStore.getState().toggleHidden();
       useUIStore.getState().toggleHidden();
       expect(useUIStore.getState().showHidden).toBe(false);
+    });
+  });
+
+  describe("localStorage永続化", () => {
+    it("setViewModeでlocalStorageに保存される", () => {
+      useUIStore.getState().setViewMode("grid");
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(stored.viewMode).toBe("grid");
+    });
+
+    it("toggleSidebarでlocalStorageに保存される", () => {
+      useUIStore.getState().toggleSidebar();
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(stored.sidebarVisible).toBe(false);
+    });
+
+    it("toggleHiddenでlocalStorageに保存される", () => {
+      useUIStore.getState().toggleHidden();
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(stored.showHidden).toBe(true);
+    });
+
+    it("localStorageから設定を復元する", () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ viewMode: "grid", sidebarVisible: false, showHidden: true })
+      );
+      const settings = loadSettings();
+      expect(settings.viewMode).toBe("grid");
+      expect(settings.sidebarVisible).toBe(false);
+      expect(settings.showHidden).toBe(true);
+    });
+
+    it("壊れたlocalStorageデータを安全に処理する", () => {
+      localStorage.setItem(STORAGE_KEY, "invalid json");
+      const settings = loadSettings();
+      expect(settings).toEqual({});
+    });
+
+    it("部分的なlocalStorageデータをマージする", () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ viewMode: "grid" }));
+      const settings = loadSettings();
+      expect(settings.viewMode).toBe("grid");
+      expect(settings.sidebarVisible).toBeUndefined();
     });
   });
 });

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -1,22 +1,57 @@
 import { create } from "zustand";
 import type { ViewMode } from "../types";
 
-interface UIStore {
+interface UISettings {
   viewMode: ViewMode;
   sidebarVisible: boolean;
   showHidden: boolean;
+}
 
+interface UIStore extends UISettings {
   setViewMode: (mode: ViewMode) => void;
   toggleSidebar: () => void;
   toggleHidden: () => void;
 }
 
-export const useUIStore = create<UIStore>((set) => ({
+const STORAGE_KEY = "tauri-filer-ui-settings";
+
+export function loadSettings(): Partial<UISettings> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveSettings(settings: UISettings) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
+
+const defaults: UISettings = {
   viewMode: "list",
   sidebarVisible: true,
   showHidden: false,
+};
 
-  setViewMode: (mode) => set({ viewMode: mode }),
-  toggleSidebar: () => set((s) => ({ sidebarVisible: !s.sidebarVisible })),
-  toggleHidden: () => set((s) => ({ showHidden: !s.showHidden })),
+const initial: UISettings = { ...defaults, ...loadSettings() };
+
+export const useUIStore = create<UIStore>((set, get) => ({
+  ...initial,
+
+  setViewMode: (mode) => {
+    set({ viewMode: mode });
+    const { viewMode, sidebarVisible, showHidden } = get();
+    saveSettings({ viewMode, sidebarVisible, showHidden });
+  },
+  toggleSidebar: () => {
+    set((s) => ({ sidebarVisible: !s.sidebarVisible }));
+    const { viewMode, sidebarVisible, showHidden } = get();
+    saveSettings({ viewMode, sidebarVisible, showHidden });
+  },
+  toggleHidden: () => {
+    set((s) => ({ showHidden: !s.showHidden }));
+    const { viewMode, sidebarVisible, showHidden } = get();
+    saveSettings({ viewMode, sidebarVisible, showHidden });
+  },
 }));


### PR DESCRIPTION
## Summary
- UIStore の設定値 (viewMode, sidebarVisible, showHidden) を localStorage で永続化
- SettingsDialog コンポーネントを新規作成（トグル、ビューモード切替）
- Toolbar にギアアイコンボタン追加、アイコンサイズを業界標準に拡大
- テスト: UIStore永続化 6件 + SettingsDialog 7件 追加（全87テスト グリーン）

closes #17

## Test plan
- [x] `bun run test` 全87テスト グリーン
- [x] `bun run tsc --noEmit` 型チェック パス
- [x] 設定ダイアログの開閉が正常に動作する
- [x] トグルスイッチで隠しファイル表示/サイドバー/ビューモードが切り替わる
- [x] 設定がlocalStorageに永続化され、リロード後も復元される

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>