### PR TITLE
feat: 設定画面の UI/UX を全面改善

### DIFF
--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -65,16 +65,17 @@ describe("SettingsDialog", () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
-  it("言語選択ラジオボタンが表示される", () => {
+  it("言語選択ドロップダウンが表示される", () => {
     render(<SettingsDialog open={true} onClose={onClose} />);
-    expect(screen.getByRole("radio", { name: "日本語" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "English" })).toBeInTheDocument();
+    const select = screen.getByRole("combobox", { name: /language/i });
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveValue("ja");
   });
 
   it("言語切替でUIStoreが更新される", () => {
     render(<SettingsDialog open={true} onClose={onClose} />);
-    const enBtn = screen.getByRole("radio", { name: "English" });
-    fireEvent.click(enBtn);
+    const select = screen.getByRole("combobox", { name: /language/i });
+    fireEvent.change(select, { target: { value: "en" } });
     expect(useUIStore.getState().language).toBe("en");
   });
 });

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useUIStore } from "../stores/ui-store";
-import { X, List, LayoutGrid } from "lucide-react";
+import { X, List, LayoutGrid, ChevronDown } from "lucide-react";
 import type { Language } from "../types";
 
 interface SettingsDialogProps {
@@ -21,117 +21,107 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
   if (!open) return null;
 
-  const handleLanguageChange = (lang: Language) => {
-    setLanguage(lang);
-  };
-
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
       data-testid="settings-overlay"
       onClick={onClose}
     >
       <div
-        className="bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-xl w-[520px] flex flex-col"
+        className="bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-xl w-[480px] flex flex-col shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between h-14 px-6 border-b border-[var(--color-border)]">
-          <h2 className="text-base font-semibold text-[var(--color-text)]">{t("settings.title")}</h2>
+        <div className="flex items-center justify-between h-12 px-5 border-b border-[var(--color-border)]">
+          <h2 className="text-sm font-semibold text-[var(--color-text)]">{t("settings.title")}</h2>
           <button
-            className="p-2 -mr-2 rounded-lg text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            className="p-1.5 -mr-1.5 rounded-md text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-hover)] transition-colors"
             onClick={onClose}
             title={t("settings.close")}
           >
-            <X size={18} />
+            <X size={16} />
           </button>
         </div>
 
         {/* Content */}
-        <div className="p-6 space-y-6">
+        <div className="px-5 py-4 space-y-5">
           {/* Display section */}
-          <div>
-            <h3 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-widest mb-3">
-              {t("settings.sectionDisplay")}
-            </h3>
+          <SettingsSection title={t("settings.sectionDisplay")}>
+            <SettingRow
+              label={t("settings.showHidden")}
+              description={t("settings.showHiddenDesc")}
+            >
+              <ToggleSwitch
+                checked={showHidden}
+                onChange={toggleHidden}
+                aria-label="Show hidden files"
+              />
+            </SettingRow>
 
-            <div className="rounded-lg border border-[var(--color-border)] overflow-hidden divide-y divide-[var(--color-border)]">
-              <SettingRow
-                label={t("settings.showHidden")}
-                description={t("settings.showHiddenDesc")}
-              >
-                <ToggleSwitch
-                  checked={showHidden}
-                  onChange={toggleHidden}
-                  aria-label="Show hidden files"
+            <SettingRow
+              label={t("settings.sidebar")}
+              description={t("settings.sidebarDesc")}
+            >
+              <ToggleSwitch
+                checked={sidebarVisible}
+                onChange={toggleSidebar}
+                aria-label="Sidebar visible"
+              />
+            </SettingRow>
+
+            <SettingRow
+              label={t("settings.viewMode")}
+              description={t("settings.viewModeDesc")}
+            >
+              <SegmentedControl>
+                <SegmentedButton
+                  label={t("settings.viewList")}
+                  icon={<List size={14} />}
+                  active={viewMode === "list"}
+                  onClick={() => setViewMode("list")}
                 />
-              </SettingRow>
-
-              <SettingRow
-                label={t("settings.sidebar")}
-                description={t("settings.sidebarDesc")}
-              >
-                <ToggleSwitch
-                  checked={sidebarVisible}
-                  onChange={toggleSidebar}
-                  aria-label="Sidebar visible"
+                <SegmentedButton
+                  label={t("settings.viewGrid")}
+                  icon={<LayoutGrid size={14} />}
+                  active={viewMode === "grid"}
+                  onClick={() => setViewMode("grid")}
                 />
-              </SettingRow>
-
-              <SettingRow
-                label={t("settings.viewMode")}
-                description={t("settings.viewModeDesc")}
-              >
-                <div
-                  className="flex rounded-lg overflow-hidden border border-[var(--color-border)]"
-                  role="radiogroup"
-                >
-                  <ViewModeButton
-                    label={t("settings.viewList")}
-                    icon={<List size={14} />}
-                    active={viewMode === "list"}
-                    onClick={() => setViewMode("list")}
-                  />
-                  <div className="w-px bg-[var(--color-border)]" />
-                  <ViewModeButton
-                    label={t("settings.viewGrid")}
-                    icon={<LayoutGrid size={14} />}
-                    active={viewMode === "grid"}
-                    onClick={() => setViewMode("grid")}
-                  />
-                </div>
-              </SettingRow>
-            </div>
-          </div>
+              </SegmentedControl>
+            </SettingRow>
+          </SettingsSection>
 
           {/* Language section */}
-          <div>
-            <h3 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-widest mb-3">
-              {t("settings.sectionLanguage")}
-            </h3>
-
-            <div className="rounded-lg border border-[var(--color-border)] overflow-hidden">
-              <div className="flex items-center justify-between min-h-[64px] px-5 py-4 bg-[var(--color-bg)]/30">
-                <div
-                  className="flex rounded-lg overflow-hidden border border-[var(--color-border)]"
-                  role="radiogroup"
-                >
-                  <ViewModeButton
-                    label="日本語"
-                    active={language === "ja"}
-                    onClick={() => handleLanguageChange("ja")}
-                  />
-                  <div className="w-px bg-[var(--color-border)]" />
-                  <ViewModeButton
-                    label="English"
-                    active={language === "en"}
-                    onClick={() => handleLanguageChange("en")}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
+          <SettingsSection title={t("settings.sectionLanguage")}>
+            <SettingRow
+              label={t("settings.language")}
+              description={t("settings.languageDesc")}
+            >
+              <LanguageSelect
+                value={language}
+                onChange={(lang) => setLanguage(lang)}
+              />
+            </SettingRow>
+          </SettingsSection>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function SettingsSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3 className="text-[11px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wide mb-2 px-1">
+        {title}
+      </h3>
+      <div className="rounded-lg border border-[var(--color-border)] overflow-hidden divide-y divide-[var(--color-border)]">
+        {children}
       </div>
     </div>
   );
@@ -147,11 +137,11 @@ function SettingRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between min-h-[64px] px-5 py-4 bg-[var(--color-bg)]/30">
-      <div className="flex flex-col gap-1 min-w-0 mr-6">
-        <span className="text-sm font-medium text-[var(--color-text)]">{label}</span>
+    <div className="flex items-center justify-between px-4 py-3 bg-[var(--color-bg-card)]">
+      <div className="flex flex-col gap-0.5 min-w-0 mr-4">
+        <span className="text-[13px] font-medium text-[var(--color-text)]">{label}</span>
         {description && (
-          <span className="text-xs text-[var(--color-text-muted)] leading-relaxed">{description}</span>
+          <span className="text-[11px] text-[var(--color-text-muted)] leading-relaxed">{description}</span>
         )}
       </div>
       <div className="shrink-0">{children}</div>
@@ -174,27 +164,38 @@ function ToggleSwitch({
       aria-checked={checked}
       aria-label={ariaLabel}
       onClick={onChange}
-      className={`relative w-12 h-7 rounded-full p-[3px] transition-colors duration-200 ${
-        checked ? "bg-[var(--color-accent)]" : "bg-[var(--color-text-muted)]/40"
+      className={`relative w-10 h-[22px] rounded-full p-[2px] transition-colors duration-200 ${
+        checked ? "bg-[var(--color-accent)]" : "bg-[var(--color-border)]"
       }`}
     >
       <span
-        className={`block w-[22px] h-[22px] rounded-full bg-white shadow transition-transform duration-200 ${
-          checked ? "translate-x-[21px]" : "translate-x-0"
+        className={`block w-[18px] h-[18px] rounded-full bg-white shadow-sm transition-transform duration-200 ${
+          checked ? "translate-x-[18px]" : "translate-x-0"
         }`}
       />
     </button>
   );
 }
 
-function ViewModeButton({
+function SegmentedControl({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="flex rounded-md overflow-hidden border border-[var(--color-border)]"
+      role="radiogroup"
+    >
+      {children}
+    </div>
+  );
+}
+
+function SegmentedButton({
   label,
   icon,
   active,
   onClick,
 }: {
   label: string;
-  icon?: React.ReactNode;
+  icon: React.ReactNode;
   active: boolean;
   onClick: () => void;
 }) {
@@ -204,7 +205,7 @@ function ViewModeButton({
       aria-checked={active}
       aria-label={label}
       onClick={onClick}
-      className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors duration-150 ${
+      className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors duration-150 ${
         active
           ? "bg-[var(--color-accent)] text-white"
           : "bg-[var(--color-bg)] text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
@@ -213,5 +214,31 @@ function ViewModeButton({
       {icon}
       {label}
     </button>
+  );
+}
+
+function LanguageSelect({
+  value,
+  onChange,
+}: {
+  value: Language;
+  onChange: (lang: Language) => void;
+}) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as Language)}
+        aria-label="Language"
+        className="appearance-none bg-[var(--color-bg)] border border-[var(--color-border)] rounded-md pl-3 pr-7 py-1.5 text-xs font-medium text-[var(--color-text)] hover:border-[var(--color-text-muted)] focus:border-[var(--color-accent)] focus:outline-none transition-colors cursor-pointer"
+      >
+        <option value="ja">日本語</option>
+        <option value="en">English</option>
+      </select>
+      <ChevronDown
+        size={12}
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)] pointer-events-none"
+      />
+    </div>
   );
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -12,6 +12,8 @@ export const en = {
   "settings.viewModeDesc": "Switch the file list display method",
   "settings.viewList": "List",
   "settings.viewGrid": "Grid",
+  "settings.language": "Language",
+  "settings.languageDesc": "Select the display language",
 
   // Toolbar
   "toolbar.toggleSidebar": "Toggle sidebar",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -12,6 +12,8 @@ export const ja = {
   "settings.viewModeDesc": "ファイル一覧の表示方法を切り替えます",
   "settings.viewList": "リスト",
   "settings.viewGrid": "グリッド",
+  "settings.language": "言語",
+  "settings.languageDesc": "表示言語を選択します",
 
   // Toolbar
   "toolbar.toggleSidebar": "サイドバーの切替",


### PR DESCRIPTION
## Summary
- 言語選択をセグメントボタンからネイティブ `<select>` ドロップダウンに変更（OS設定やVS Codeなどの標準パターンに準拠）
- SettingRow / ToggleSwitch のコントラスト・視認性を大幅に改善
- セクション構造を `SettingsSection` コンポーネントで統一
- `ViewModeButton` を `SegmentedButton` に分離し、`icon` を必須に戻す（責務の明確化）
- パディング・フォントサイズ・余白・ダイアログ幅の全体最適化

## 主な改善点

| 項目 | Before | After |
|---|---|---|
| 言語選択 | セグメントボタン（ViewModeButton流用） | `<select>` ドロップダウン |
| ToggleSwitch OFF状態 | `text-muted/40`（ほぼ見えない） | `var(--color-border)`（明確に視認可能） |
| セクション構造 | 言語セクションだけSettingRow未使用 | 全セクション統一レイアウト |
| ダイアログ幅 | 520px | 480px（よりコンパクト） |
| オーバーレイ | `bg-black/50`（不統一） | `bg-black/60`（他ダイアログと統一） |
| SettingRow背景 | `bg-[var(--color-bg)]/30`（透明すぎ） | `bg-[var(--color-bg-card)]`（明確） |

## Test plan
- [x] `bun run test` — 114テスト全通過
- [x] `bunx tsc --noEmit` — 型チェックエラーなし
- [ ] 手動確認: 設定画面の視認性・操作性を目視確認

closes #27
closes #22

Generated with [Claude Code](https://claude.com/claude-code)