### PR TITLE
feat: 設定画面を2ペインレイアウトにリデザイン

### DIFF
--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -67,6 +67,7 @@ describe("SettingsDialog", () => {
 
   it("言語選択ドロップダウンが表示される", () => {
     render(<SettingsDialog open={true} onClose={onClose} />);
+    fireEvent.click(screen.getByText("Language"));
     const select = screen.getByRole("combobox", { name: /language/i });
     expect(select).toBeInTheDocument();
     expect(select).toHaveValue("ja");
@@ -74,8 +75,26 @@ describe("SettingsDialog", () => {
 
   it("言語切替でUIStoreが更新される", () => {
     render(<SettingsDialog open={true} onClose={onClose} />);
+    fireEvent.click(screen.getByText("Language"));
     const select = screen.getByRole("combobox", { name: /language/i });
     fireEvent.change(select, { target: { value: "en" } });
     expect(useUIStore.getState().language).toBe("en");
+  });
+
+  it("Escapeキーでダイアログが閉じる", () => {
+    render(<SettingsDialog open={true} onClose={onClose} />);
+    const dialog = screen.getByRole("dialog");
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("サイドバーのカテゴリ切替が動作する", () => {
+    render(<SettingsDialog open={true} onClose={onClose} />);
+    expect(screen.getByRole("switch", { name: /hidden/i })).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: /language/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Language"));
+    expect(screen.getByRole("combobox", { name: /language/i })).toBeInTheDocument();
+    expect(screen.queryByRole("switch", { name: /hidden/i })).not.toBeInTheDocument();
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -47,3 +47,20 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-muted);
 }
+
+/* ダイアログアニメーション */
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes dialog-in {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- 設定画面を左サイドバー + 右コンテンツの2ペインレイアウトにリデザイン
- カテゴリ別のナビゲーションで設定項目へのアクセス性を向上
- テストを追加

## Test plan
- [x] 設定画面が2ペインレイアウトで表示される
- [x] カテゴリ切り替えが正常に動作する
- [x] テストが通る

closes #22