### PR TITLE
fix: 設定画面の左右余白を広げて窮屈さを解消

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -68,7 +68,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         onKeyDown={(e) => {
           if (e.key === "Escape") onClose();
         }}
-        className="bg-[var(--color-bg-card)] rounded-xl w-[720px] h-[520px] flex flex-col shadow-2xl shadow-black/40 animate-[dialog-in_200ms_ease-out] outline-none"
+        className="bg-[var(--color-bg-card)] rounded-xl w-[800px] h-[520px] flex flex-col shadow-2xl shadow-black/40 animate-[dialog-in_200ms_ease-out] outline-none"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
@@ -91,7 +91,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         {/* Two-pane body */}
         <div className="flex flex-1 min-h-0">
           {/* Left sidebar */}
-          <nav className="w-[200px] shrink-0 border-r border-[var(--color-border)] py-4 px-4">
+          <nav className="w-[200px] shrink-0 border-r border-[var(--color-border)] py-4 px-3">
             <ul className="space-y-0.5">
               {sections.map((section) => (
                 <li key={section.id}>
@@ -112,7 +112,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           </nav>
 
           {/* Right content pane */}
-          <div className="flex-1 overflow-y-auto px-10 py-8">
+          <div className="flex-1 overflow-y-auto px-8 py-8">
             {activeSection === "display" && (
               <SettingsPane title={t("settings.sectionDisplay")}>
                 <SettingRow

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test-setup.ts"],
     passWithNoTests: true,
+    exclude: ["e2e/**", "node_modules/**"],
   },
 });


### PR DESCRIPTION
## Summary
- ダイアログ幅を 720px → 800px に拡大し、右ペインのコンテンツ領域を広げた
- サイドバーと右ペインのパディングを微調整してバランスを改善
- Vitest が e2e ディレクトリの Playwright テストを誤検出する問題を修正

## Test plan
- [x] 型チェック通過
- [x] ユニットテスト全パス (14 files, 116 tests)
- [ ] 設定画面を開いて左右に十分な余白があることを目視確認

closes #33