### PR TITLE
chore: v0.1.2 リリース

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-filer",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Cross-platform desktop file manager built with Tauri 2 + React 19",
   "author": "win-chanma",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-filer"
-version = "0.1.1"
+version = "0.1.2"
 description = "Desktop File Manager"
 authors = ["win-chanma"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tauri Filer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.win.tauri-filer",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- バージョンを 0.1.2 に更新 (package.json, tauri.conf.json, Cargo.toml)

## v0.1.1 → v0.1.2 の変更点
- 設定画面を2ペインレイアウトにリデザイン (#30)
- Playwright CLI の導入と E2E テスト基盤構築 (#32)
- 設定画面の余白問題を修正 (#36)
- パッケージマネージャーを npm → bun に修正 (#35)