### PR TITLE
feat: 20テーマ追加 + Attribution整備 refs #40

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,22 @@
+# Color Theme Credits
+
+This project includes color themes inspired by the following open source projects.
+
+| Theme | Author | Source | License |
+|-------|--------|--------|---------|
+| Dracula | Zeno Rocha | https://github.com/dracula/dracula-theme | MIT |
+| Catppuccin (Mocha, Frappé, Macchiato, Latte) | Catppuccin Org | https://github.com/catppuccin/catppuccin | MIT |
+| Nord | Sven Greb (Arctic Ice Studio) | https://github.com/nordtheme/nord | MIT |
+| Solarized (Dark, Light) | Ethan Schoonover | https://github.com/altercation/solarized | MIT |
+| One Dark | GitHub Inc. (Atom) | https://github.com/atom/one-dark-syntax | MIT |
+| Atom One Light | GitHub Inc. (Atom) | https://github.com/atom/one-light-syntax | MIT |
+| Tokyo Night | Enkelondon | https://github.com/tokyo-night/tokyo-night-vscode-theme | MIT |
+| Gruvbox (Dark, Light) | Pavel Pertsev (morhetz) | https://github.com/morhetz/gruvbox | MIT |
+| GitHub (Dark, Light) | GitHub (Primer) | https://github.com/primer/github-vscode-theme | MIT |
+| Rosé Pine (Base, Moon, Dawn) | Rosé Pine | https://github.com/rose-pine/rose-pine-theme | MIT |
+| Everforest | sainnhe | https://github.com/sainnhe/everforest | MIT |
+| Kanagawa | rebelot | https://github.com/rebelot/kanagawa.nvim | MIT |
+| Ayu (Dark, Light, Mirage) | Ike Ku (ayu-theme) | https://github.com/ayu-theme/ayu-colors | MIT |
+| Palenight | Olaolu Olawuyi (whizkydee) | https://github.com/whizkydee/vscode-palenight-theme | MIT |
+| Synthwave '84 | Robb Owen | https://github.com/robb0wen/synthwave-vscode | MIT |
+| Horizon | Jonathan Olaleye (jolaleye) | https://github.com/jolaleye/horizon-theme-vscode | MIT |

--- a/src/themes/atom-one-light.ts
+++ b/src/themes/atom-one-light.ts
@@ -1,0 +1,46 @@
+// Theme: Atom One Light
+// Author: GitHub Inc. (Atom)
+// Source: https://github.com/atom/one-light-syntax
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const atomOneLightTheme: Theme = {
+  id: "atom-one-light",
+  name: "Atom One Light",
+  nameJa: "Atom One Light",
+  isDark: false,
+  colors: {
+    bg: "#fafafa",
+    bgCard: "#f0f0f0",
+    bgHover: "#e5e5e6",
+    border: "#d0d0d0",
+    accent: "#4078f2",
+    accentLight: "#526fff",
+    text: "#383a42",
+    textDim: "#696c77",
+    textMuted: "#a0a1a7",
+    bgDeep: "#eaeaeb",
+    bgTabBar: "#f0f0f0",
+    selectionBg: "rgba(64,120,242,0.1)",
+    selectionRing: "rgba(64,120,242,0.35)",
+    dropTargetBg: "rgba(64,120,242,0.15)",
+    dropTargetRing: "#4078f2",
+    danger: "#e45649",
+    dangerHover: "#ca1243",
+    sidebarActive: "#4078f2",
+    sidebarActiveBg: "rgba(64,120,242,0.08)",
+    pathText: "#0184bc",
+    dirName: "#a626a4",
+    iconFolder: "#4078f2",
+    iconImage: "#50a14f",
+    iconVideo: "#e45649",
+    iconAudio: "#c18401",
+    iconCode: "#0184bc",
+    iconJson: "#c18401",
+    iconArchive: "#986801",
+    iconText: "#696c77",
+    iconDefault: "#a0a1a7",
+  },
+  preview: ["#fafafa", "#4078f2", "#383a42"],
+};

--- a/src/themes/ayu-dark.ts
+++ b/src/themes/ayu-dark.ts
@@ -1,0 +1,46 @@
+// Theme: Ayu Dark
+// Author: Ike Ku (ayu-theme)
+// Source: https://github.com/ayu-theme/ayu-colors
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const ayuDarkTheme: Theme = {
+  id: "ayu-dark",
+  name: "Ayu Dark",
+  nameJa: "Ayu Dark",
+  isDark: true,
+  colors: {
+    bg: "#0b0e14",
+    bgCard: "#0d1017",
+    bgHover: "#131721",
+    border: "#253340",
+    accent: "#e6b450",
+    accentLight: "#ffb454",
+    text: "#bfbdb6",
+    textDim: "#9b9b9b",
+    textMuted: "#636a72",
+    bgDeep: "#0b0e14",
+    bgTabBar: "#0d1017",
+    selectionBg: "rgba(230,180,80,0.12)",
+    selectionRing: "rgba(230,180,80,0.35)",
+    dropTargetBg: "rgba(230,180,80,0.2)",
+    dropTargetRing: "#e6b450",
+    danger: "#d95757",
+    dangerHover: "#f07178",
+    sidebarActive: "#e6b450",
+    sidebarActiveBg: "rgba(230,180,80,0.08)",
+    pathText: "#95e6cb",
+    dirName: "#d2a6ff",
+    iconFolder: "#e6b450",
+    iconImage: "#aad94c",
+    iconVideo: "#f07178",
+    iconAudio: "#ffb454",
+    iconCode: "#95e6cb",
+    iconJson: "#ffb454",
+    iconArchive: "#ff8f40",
+    iconText: "#9b9b9b",
+    iconDefault: "#636a72",
+  },
+  preview: ["#0b0e14", "#e6b450", "#bfbdb6"],
+};

--- a/src/themes/ayu-light.ts
+++ b/src/themes/ayu-light.ts
@@ -1,0 +1,46 @@
+// Theme: Ayu Light
+// Author: Ike Ku (ayu-theme)
+// Source: https://github.com/ayu-theme/ayu-colors
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const ayuLightTheme: Theme = {
+  id: "ayu-light",
+  name: "Ayu Light",
+  nameJa: "Ayu Light",
+  isDark: false,
+  colors: {
+    bg: "#fafafa",
+    bgCard: "#f0f0f0",
+    bgHover: "#e8e8e8",
+    border: "#d4d4d4",
+    accent: "#ff9940",
+    accentLight: "#f2ae49",
+    text: "#575f66",
+    textDim: "#828c99",
+    textMuted: "#abb0b6",
+    bgDeep: "#f0f0f0",
+    bgTabBar: "#f0f0f0",
+    selectionBg: "rgba(255,153,64,0.1)",
+    selectionRing: "rgba(255,153,64,0.35)",
+    dropTargetBg: "rgba(255,153,64,0.15)",
+    dropTargetRing: "#ff9940",
+    danger: "#e65050",
+    dangerHover: "#f07171",
+    sidebarActive: "#ff9940",
+    sidebarActiveBg: "rgba(255,153,64,0.08)",
+    pathText: "#4cbf99",
+    dirName: "#a37acc",
+    iconFolder: "#ff9940",
+    iconImage: "#86b300",
+    iconVideo: "#f07171",
+    iconAudio: "#f2ae49",
+    iconCode: "#4cbf99",
+    iconJson: "#f2ae49",
+    iconArchive: "#fa8d3e",
+    iconText: "#828c99",
+    iconDefault: "#abb0b6",
+  },
+  preview: ["#fafafa", "#ff9940", "#575f66"],
+};

--- a/src/themes/ayu-mirage.ts
+++ b/src/themes/ayu-mirage.ts
@@ -1,0 +1,46 @@
+// Theme: Ayu Mirage
+// Author: Ike Ku (ayu-theme)
+// Source: https://github.com/ayu-theme/ayu-colors
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const ayuMirageTheme: Theme = {
+  id: "ayu-mirage",
+  name: "Ayu Mirage",
+  nameJa: "Ayu Mirage",
+  isDark: true,
+  colors: {
+    bg: "#242936",
+    bgCard: "#1f2430",
+    bgHover: "#2d3443",
+    border: "#3d4455",
+    accent: "#ffcc66",
+    accentLight: "#ffd580",
+    text: "#cccac2",
+    textDim: "#9b9b9b",
+    textMuted: "#6c7380",
+    bgDeep: "#1a1f29",
+    bgTabBar: "#1f2430",
+    selectionBg: "rgba(255,204,102,0.12)",
+    selectionRing: "rgba(255,204,102,0.35)",
+    dropTargetBg: "rgba(255,204,102,0.2)",
+    dropTargetRing: "#ffcc66",
+    danger: "#f28779",
+    dangerHover: "#ff9580",
+    sidebarActive: "#ffcc66",
+    sidebarActiveBg: "rgba(255,204,102,0.08)",
+    pathText: "#95e6cb",
+    dirName: "#d4bfff",
+    iconFolder: "#ffcc66",
+    iconImage: "#bae67e",
+    iconVideo: "#f28779",
+    iconAudio: "#ffd580",
+    iconCode: "#95e6cb",
+    iconJson: "#ffd580",
+    iconArchive: "#ffa759",
+    iconText: "#9b9b9b",
+    iconDefault: "#6c7380",
+  },
+  preview: ["#242936", "#ffcc66", "#cccac2"],
+};

--- a/src/themes/catppuccin-frappe.ts
+++ b/src/themes/catppuccin-frappe.ts
@@ -1,0 +1,46 @@
+// Theme: Catppuccin Frappé
+// Author: Catppuccin Org
+// Source: https://github.com/catppuccin/catppuccin
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const catppuccinFrappeTheme: Theme = {
+  id: "catppuccin-frappe",
+  name: "Catppuccin Frappé",
+  nameJa: "Catppuccin Frappé",
+  isDark: true,
+  colors: {
+    bg: "#303446",
+    bgCard: "#292c3c",
+    bgHover: "#414559",
+    border: "#51576d",
+    accent: "#ca9ee6",
+    accentLight: "#babbf1",
+    text: "#c6d0f5",
+    textDim: "#a5adce",
+    textMuted: "#737994",
+    bgDeep: "#232634",
+    bgTabBar: "#292c3c",
+    selectionBg: "rgba(202,158,230,0.15)",
+    selectionRing: "rgba(202,158,230,0.4)",
+    dropTargetBg: "rgba(202,158,230,0.25)",
+    dropTargetRing: "#ca9ee6",
+    danger: "#e78284",
+    dangerHover: "#ea999c",
+    sidebarActive: "#ca9ee6",
+    sidebarActiveBg: "rgba(202,158,230,0.1)",
+    pathText: "#81c8be",
+    dirName: "#babbf1",
+    iconFolder: "#8caaee",
+    iconImage: "#a6d189",
+    iconVideo: "#e78284",
+    iconAudio: "#e5c890",
+    iconCode: "#81c8be",
+    iconJson: "#e5c890",
+    iconArchive: "#ef9f76",
+    iconText: "#a5adce",
+    iconDefault: "#737994",
+  },
+  preview: ["#303446", "#ca9ee6", "#c6d0f5"],
+};

--- a/src/themes/catppuccin-latte.ts
+++ b/src/themes/catppuccin-latte.ts
@@ -1,0 +1,46 @@
+// Theme: Catppuccin Latte
+// Author: Catppuccin Org
+// Source: https://github.com/catppuccin/catppuccin
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const catppuccinLatteTheme: Theme = {
+  id: "catppuccin-latte",
+  name: "Catppuccin Latte",
+  nameJa: "Catppuccin Latte",
+  isDark: false,
+  colors: {
+    bg: "#eff1f5",
+    bgCard: "#e6e9ef",
+    bgHover: "#dce0e8",
+    border: "#ccd0da",
+    accent: "#8839ef",
+    accentLight: "#7287fd",
+    text: "#4c4f69",
+    textDim: "#6c6f85",
+    textMuted: "#9ca0b0",
+    bgDeep: "#e6e9ef",
+    bgTabBar: "#e6e9ef",
+    selectionBg: "rgba(136,57,239,0.1)",
+    selectionRing: "rgba(136,57,239,0.35)",
+    dropTargetBg: "rgba(136,57,239,0.15)",
+    dropTargetRing: "#8839ef",
+    danger: "#d20f39",
+    dangerHover: "#e64553",
+    sidebarActive: "#8839ef",
+    sidebarActiveBg: "rgba(136,57,239,0.08)",
+    pathText: "#179299",
+    dirName: "#7287fd",
+    iconFolder: "#1e66f5",
+    iconImage: "#40a02b",
+    iconVideo: "#d20f39",
+    iconAudio: "#df8e1d",
+    iconCode: "#179299",
+    iconJson: "#df8e1d",
+    iconArchive: "#fe640b",
+    iconText: "#6c6f85",
+    iconDefault: "#9ca0b0",
+  },
+  preview: ["#eff1f5", "#8839ef", "#4c4f69"],
+};

--- a/src/themes/catppuccin-macchiato.ts
+++ b/src/themes/catppuccin-macchiato.ts
@@ -1,0 +1,46 @@
+// Theme: Catppuccin Macchiato
+// Author: Catppuccin Org
+// Source: https://github.com/catppuccin/catppuccin
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const catppuccinMacchiatoTheme: Theme = {
+  id: "catppuccin-macchiato",
+  name: "Catppuccin Macchiato",
+  nameJa: "Catppuccin Macchiato",
+  isDark: true,
+  colors: {
+    bg: "#24273a",
+    bgCard: "#1e2030",
+    bgHover: "#363a4f",
+    border: "#494d64",
+    accent: "#c6a0f6",
+    accentLight: "#b7bdf8",
+    text: "#cad3f5",
+    textDim: "#a5adcb",
+    textMuted: "#6e738d",
+    bgDeep: "#181926",
+    bgTabBar: "#1e2030",
+    selectionBg: "rgba(198,160,246,0.15)",
+    selectionRing: "rgba(198,160,246,0.4)",
+    dropTargetBg: "rgba(198,160,246,0.25)",
+    dropTargetRing: "#c6a0f6",
+    danger: "#ed8796",
+    dangerHover: "#f0a0ac",
+    sidebarActive: "#c6a0f6",
+    sidebarActiveBg: "rgba(198,160,246,0.1)",
+    pathText: "#8bd5ca",
+    dirName: "#b7bdf8",
+    iconFolder: "#8aadf4",
+    iconImage: "#a6da95",
+    iconVideo: "#ed8796",
+    iconAudio: "#eed49f",
+    iconCode: "#8bd5ca",
+    iconJson: "#eed49f",
+    iconArchive: "#f5a97f",
+    iconText: "#a5adcb",
+    iconDefault: "#6e738d",
+  },
+  preview: ["#24273a", "#c6a0f6", "#cad3f5"],
+};

--- a/src/themes/catppuccin-mocha.ts
+++ b/src/themes/catppuccin-mocha.ts
@@ -1,3 +1,8 @@
+// Theme: Catppuccin Mocha
+// Author: Catppuccin Org
+// Source: https://github.com/catppuccin/catppuccin
+// License: MIT
+
 import type { Theme } from "../types";
 
 export const catppuccinMochaTheme: Theme = {

--- a/src/themes/dracula.ts
+++ b/src/themes/dracula.ts
@@ -1,3 +1,8 @@
+// Theme: Dracula
+// Author: Zeno Rocha
+// Source: https://github.com/dracula/dracula-theme
+// License: MIT
+
 import type { Theme } from "../types";
 
 export const draculaTheme: Theme = {

--- a/src/themes/everforest.ts
+++ b/src/themes/everforest.ts
@@ -1,0 +1,46 @@
+// Theme: Everforest
+// Author: sainnhe
+// Source: https://github.com/sainnhe/everforest
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const everforestTheme: Theme = {
+  id: "everforest",
+  name: "Everforest",
+  nameJa: "Everforest",
+  isDark: true,
+  colors: {
+    bg: "#2d353b",
+    bgCard: "#343f44",
+    bgHover: "#3d484d",
+    border: "#4f585e",
+    accent: "#a7c080",
+    accentLight: "#83c092",
+    text: "#d3c6aa",
+    textDim: "#9da9a0",
+    textMuted: "#7a8478",
+    bgDeep: "#272e33",
+    bgTabBar: "#343f44",
+    selectionBg: "rgba(167,192,128,0.15)",
+    selectionRing: "rgba(167,192,128,0.4)",
+    dropTargetBg: "rgba(167,192,128,0.25)",
+    dropTargetRing: "#a7c080",
+    danger: "#e67e80",
+    dangerHover: "#f09090",
+    sidebarActive: "#a7c080",
+    sidebarActiveBg: "rgba(167,192,128,0.1)",
+    pathText: "#83c092",
+    dirName: "#d699b6",
+    iconFolder: "#a7c080",
+    iconImage: "#83c092",
+    iconVideo: "#e67e80",
+    iconAudio: "#dbbc7f",
+    iconCode: "#7fbbb3",
+    iconJson: "#dbbc7f",
+    iconArchive: "#e69875",
+    iconText: "#9da9a0",
+    iconDefault: "#7a8478",
+  },
+  preview: ["#2d353b", "#a7c080", "#d3c6aa"],
+};

--- a/src/themes/github-dark.ts
+++ b/src/themes/github-dark.ts
@@ -1,0 +1,46 @@
+// Theme: GitHub Dark
+// Author: GitHub (Primer)
+// Source: https://github.com/primer/github-vscode-theme
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const githubDarkTheme: Theme = {
+  id: "github-dark",
+  name: "GitHub Dark",
+  nameJa: "GitHub Dark",
+  isDark: true,
+  colors: {
+    bg: "#0d1117",
+    bgCard: "#161b22",
+    bgHover: "#1c2129",
+    border: "#30363d",
+    accent: "#58a6ff",
+    accentLight: "#79c0ff",
+    text: "#c9d1d9",
+    textDim: "#8b949e",
+    textMuted: "#6e7681",
+    bgDeep: "#010409",
+    bgTabBar: "#161b22",
+    selectionBg: "rgba(88,166,255,0.15)",
+    selectionRing: "rgba(88,166,255,0.4)",
+    dropTargetBg: "rgba(88,166,255,0.25)",
+    dropTargetRing: "#58a6ff",
+    danger: "#f85149",
+    dangerHover: "#ff7b72",
+    sidebarActive: "#58a6ff",
+    sidebarActiveBg: "rgba(88,166,255,0.1)",
+    pathText: "#56d364",
+    dirName: "#d2a8ff",
+    iconFolder: "#58a6ff",
+    iconImage: "#56d364",
+    iconVideo: "#f85149",
+    iconAudio: "#d29922",
+    iconCode: "#79c0ff",
+    iconJson: "#d29922",
+    iconArchive: "#f0883e",
+    iconText: "#8b949e",
+    iconDefault: "#6e7681",
+  },
+  preview: ["#0d1117", "#58a6ff", "#c9d1d9"],
+};

--- a/src/themes/github-light.ts
+++ b/src/themes/github-light.ts
@@ -1,0 +1,46 @@
+// Theme: GitHub Light
+// Author: GitHub (Primer)
+// Source: https://github.com/primer/github-vscode-theme
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const githubLightTheme: Theme = {
+  id: "github-light",
+  name: "GitHub Light",
+  nameJa: "GitHub Light",
+  isDark: false,
+  colors: {
+    bg: "#ffffff",
+    bgCard: "#f6f8fa",
+    bgHover: "#eaeef2",
+    border: "#d0d7de",
+    accent: "#0969da",
+    accentLight: "#218bff",
+    text: "#1f2328",
+    textDim: "#656d76",
+    textMuted: "#8c959f",
+    bgDeep: "#f6f8fa",
+    bgTabBar: "#f6f8fa",
+    selectionBg: "rgba(9,105,218,0.1)",
+    selectionRing: "rgba(9,105,218,0.4)",
+    dropTargetBg: "rgba(9,105,218,0.15)",
+    dropTargetRing: "#0969da",
+    danger: "#cf222e",
+    dangerHover: "#a40e26",
+    sidebarActive: "#0969da",
+    sidebarActiveBg: "rgba(9,105,218,0.08)",
+    pathText: "#0550ae",
+    dirName: "#8250df",
+    iconFolder: "#0969da",
+    iconImage: "#1a7f37",
+    iconVideo: "#cf222e",
+    iconAudio: "#9a6700",
+    iconCode: "#0550ae",
+    iconJson: "#9a6700",
+    iconArchive: "#bc4c00",
+    iconText: "#656d76",
+    iconDefault: "#8c959f",
+  },
+  preview: ["#ffffff", "#0969da", "#1f2328"],
+};

--- a/src/themes/gruvbox-dark.ts
+++ b/src/themes/gruvbox-dark.ts
@@ -1,0 +1,46 @@
+// Theme: Gruvbox Dark
+// Author: Pavel Pertsev (morhetz)
+// Source: https://github.com/morhetz/gruvbox
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const gruvboxDarkTheme: Theme = {
+  id: "gruvbox-dark",
+  name: "Gruvbox Dark",
+  nameJa: "Gruvbox Dark",
+  isDark: true,
+  colors: {
+    bg: "#282828",
+    bgCard: "#1d2021",
+    bgHover: "#3c3836",
+    border: "#504945",
+    accent: "#458588",
+    accentLight: "#83a598",
+    text: "#ebdbb2",
+    textDim: "#d5c4a1",
+    textMuted: "#928374",
+    bgDeep: "#1d2021",
+    bgTabBar: "#1d2021",
+    selectionBg: "rgba(69,133,136,0.25)",
+    selectionRing: "rgba(69,133,136,0.5)",
+    dropTargetBg: "rgba(69,133,136,0.3)",
+    dropTargetRing: "#83a598",
+    danger: "#cc241d",
+    dangerHover: "#fb4934",
+    sidebarActive: "#83a598",
+    sidebarActiveBg: "rgba(131,165,152,0.1)",
+    pathText: "#8ec07c",
+    dirName: "#d3869b",
+    iconFolder: "#83a598",
+    iconImage: "#b8bb26",
+    iconVideo: "#fb4934",
+    iconAudio: "#fabd2f",
+    iconCode: "#8ec07c",
+    iconJson: "#fabd2f",
+    iconArchive: "#fe8019",
+    iconText: "#d5c4a1",
+    iconDefault: "#928374",
+  },
+  preview: ["#282828", "#83a598", "#ebdbb2"],
+};

--- a/src/themes/gruvbox-light.ts
+++ b/src/themes/gruvbox-light.ts
@@ -1,0 +1,46 @@
+// Theme: Gruvbox Light
+// Author: Pavel Pertsev (morhetz)
+// Source: https://github.com/morhetz/gruvbox
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const gruvboxLightTheme: Theme = {
+  id: "gruvbox-light",
+  name: "Gruvbox Light",
+  nameJa: "Gruvbox Light",
+  isDark: false,
+  colors: {
+    bg: "#fbf1c7",
+    bgCard: "#f2e5bc",
+    bgHover: "#ebdbb2",
+    border: "#d5c4a1",
+    accent: "#458588",
+    accentLight: "#076678",
+    text: "#3c3836",
+    textDim: "#504945",
+    textMuted: "#928374",
+    bgDeep: "#f2e5bc",
+    bgTabBar: "#f2e5bc",
+    selectionBg: "rgba(69,133,136,0.15)",
+    selectionRing: "rgba(69,133,136,0.4)",
+    dropTargetBg: "rgba(69,133,136,0.2)",
+    dropTargetRing: "#458588",
+    danger: "#cc241d",
+    dangerHover: "#9d0006",
+    sidebarActive: "#076678",
+    sidebarActiveBg: "rgba(7,102,120,0.1)",
+    pathText: "#427b58",
+    dirName: "#8f3f71",
+    iconFolder: "#076678",
+    iconImage: "#79740e",
+    iconVideo: "#9d0006",
+    iconAudio: "#b57614",
+    iconCode: "#427b58",
+    iconJson: "#b57614",
+    iconArchive: "#af3a03",
+    iconText: "#504945",
+    iconDefault: "#928374",
+  },
+  preview: ["#fbf1c7", "#458588", "#3c3836"],
+};

--- a/src/themes/horizon.ts
+++ b/src/themes/horizon.ts
@@ -1,0 +1,46 @@
+// Theme: Horizon
+// Author: Jonathan Olaleye (jolaleye)
+// Source: https://github.com/jolaleye/horizon-theme-vscode
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const horizonTheme: Theme = {
+  id: "horizon",
+  name: "Horizon",
+  nameJa: "Horizon",
+  isDark: true,
+  colors: {
+    bg: "#1c1e26",
+    bgCard: "#232530",
+    bgHover: "#2e303e",
+    border: "#3d3f4e",
+    accent: "#e95678",
+    accentLight: "#fab795",
+    text: "#d5d8da",
+    textDim: "#bbbbbb",
+    textMuted: "#6c6f93",
+    bgDeep: "#16161c",
+    bgTabBar: "#232530",
+    selectionBg: "rgba(233,86,120,0.15)",
+    selectionRing: "rgba(233,86,120,0.4)",
+    dropTargetBg: "rgba(233,86,120,0.25)",
+    dropTargetRing: "#e95678",
+    danger: "#e95678",
+    dangerHover: "#f09383",
+    sidebarActive: "#e95678",
+    sidebarActiveBg: "rgba(233,86,120,0.1)",
+    pathText: "#25b0bc",
+    dirName: "#b877db",
+    iconFolder: "#e95678",
+    iconImage: "#09f7a0",
+    iconVideo: "#e95678",
+    iconAudio: "#fab795",
+    iconCode: "#25b0bc",
+    iconJson: "#fab795",
+    iconArchive: "#f09383",
+    iconText: "#bbbbbb",
+    iconDefault: "#6c6f93",
+  },
+  preview: ["#1c1e26", "#e95678", "#d5d8da"],
+};

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -2,19 +2,59 @@ import type { Theme, ThemeId } from "../types";
 import { defaultTheme } from "./default";
 import { draculaTheme } from "./dracula";
 import { catppuccinMochaTheme } from "./catppuccin-mocha";
+import { catppuccinLatteTheme } from "./catppuccin-latte";
+import { catppuccinFrappeTheme } from "./catppuccin-frappe";
+import { catppuccinMacchiatoTheme } from "./catppuccin-macchiato";
 import { nordTheme } from "./nord";
 import { solarizedDarkTheme } from "./solarized-dark";
 import { solarizedLightTheme } from "./solarized-light";
 import { oneDarkTheme } from "./one-dark";
+import { atomOneLightTheme } from "./atom-one-light";
+import { tokyoNightTheme } from "./tokyo-night";
+import { gruvboxDarkTheme } from "./gruvbox-dark";
+import { gruvboxLightTheme } from "./gruvbox-light";
+import { githubDarkTheme } from "./github-dark";
+import { githubLightTheme } from "./github-light";
+import { rosePineTheme } from "./rose-pine";
+import { rosePineMoonTheme } from "./rose-pine-moon";
+import { rosePineDawnTheme } from "./rose-pine-dawn";
+import { everforestTheme } from "./everforest";
+import { kanagawaTheme } from "./kanagawa";
+import { ayuDarkTheme } from "./ayu-dark";
+import { ayuLightTheme } from "./ayu-light";
+import { ayuMirageTheme } from "./ayu-mirage";
+import { palenightTheme } from "./palenight";
+import { synthwave84Theme } from "./synthwave-84";
+import { horizonTheme } from "./horizon";
 
 const themeRegistry: Record<ThemeId, Theme> = {
   default: defaultTheme,
   dracula: draculaTheme,
   "catppuccin-mocha": catppuccinMochaTheme,
+  "catppuccin-latte": catppuccinLatteTheme,
+  "catppuccin-frappe": catppuccinFrappeTheme,
+  "catppuccin-macchiato": catppuccinMacchiatoTheme,
   nord: nordTheme,
   "solarized-dark": solarizedDarkTheme,
   "solarized-light": solarizedLightTheme,
   "one-dark": oneDarkTheme,
+  "atom-one-light": atomOneLightTheme,
+  "tokyo-night": tokyoNightTheme,
+  "gruvbox-dark": gruvboxDarkTheme,
+  "gruvbox-light": gruvboxLightTheme,
+  "github-dark": githubDarkTheme,
+  "github-light": githubLightTheme,
+  "rose-pine": rosePineTheme,
+  "rose-pine-moon": rosePineMoonTheme,
+  "rose-pine-dawn": rosePineDawnTheme,
+  everforest: everforestTheme,
+  kanagawa: kanagawaTheme,
+  "ayu-dark": ayuDarkTheme,
+  "ayu-light": ayuLightTheme,
+  "ayu-mirage": ayuMirageTheme,
+  palenight: palenightTheme,
+  "synthwave-84": synthwave84Theme,
+  horizon: horizonTheme,
 };
 
 export function getTheme(id: ThemeId): Theme {

--- a/src/themes/kanagawa.ts
+++ b/src/themes/kanagawa.ts
@@ -1,0 +1,46 @@
+// Theme: Kanagawa
+// Author: rebelot
+// Source: https://github.com/rebelot/kanagawa.nvim
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const kanagawaTheme: Theme = {
+  id: "kanagawa",
+  name: "Kanagawa",
+  nameJa: "Kanagawa",
+  isDark: true,
+  colors: {
+    bg: "#1f1f28",
+    bgCard: "#2a2a37",
+    bgHover: "#363646",
+    border: "#54546d",
+    accent: "#7e9cd8",
+    accentLight: "#7fb4ca",
+    text: "#dcd7ba",
+    textDim: "#c8c093",
+    textMuted: "#727169",
+    bgDeep: "#16161d",
+    bgTabBar: "#2a2a37",
+    selectionBg: "rgba(126,156,216,0.15)",
+    selectionRing: "rgba(126,156,216,0.4)",
+    dropTargetBg: "rgba(126,156,216,0.25)",
+    dropTargetRing: "#7e9cd8",
+    danger: "#e82424",
+    dangerHover: "#ff5d62",
+    sidebarActive: "#7e9cd8",
+    sidebarActiveBg: "rgba(126,156,216,0.1)",
+    pathText: "#6a9589",
+    dirName: "#957fb8",
+    iconFolder: "#7e9cd8",
+    iconImage: "#98bb6c",
+    iconVideo: "#ff5d62",
+    iconAudio: "#e6c384",
+    iconCode: "#7fb4ca",
+    iconJson: "#e6c384",
+    iconArchive: "#ffa066",
+    iconText: "#c8c093",
+    iconDefault: "#727169",
+  },
+  preview: ["#1f1f28", "#7e9cd8", "#dcd7ba"],
+};

--- a/src/themes/nord.ts
+++ b/src/themes/nord.ts
@@ -1,3 +1,8 @@
+// Theme: Nord
+// Author: Sven Greb (Arctic Ice Studio)
+// Source: https://github.com/nordtheme/nord
+// License: MIT
+
 import type { Theme } from "../types";
 
 export const nordTheme: Theme = {

--- a/src/themes/one-dark.ts
+++ b/src/themes/one-dark.ts
@@ -1,3 +1,8 @@
+// Theme: One Dark
+// Author: GitHub Inc. (Atom)
+// Source: https://github.com/atom/one-dark-syntax
+// License: MIT
+
 import type { Theme } from "../types";
 
 export const oneDarkTheme: Theme = {

--- a/src/themes/palenight.ts
+++ b/src/themes/palenight.ts
@@ -1,0 +1,46 @@
+// Theme: Palenight
+// Author: Olaolu Olawuyi (whizkydee)
+// Source: https://github.com/whizkydee/vscode-palenight-theme
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const palenightTheme: Theme = {
+  id: "palenight",
+  name: "Palenight",
+  nameJa: "Palenight",
+  isDark: true,
+  colors: {
+    bg: "#292d3e",
+    bgCard: "#1e2132",
+    bgHover: "#32374d",
+    border: "#444867",
+    accent: "#82aaff",
+    accentLight: "#89bbff",
+    text: "#a6accd",
+    textDim: "#8796b0",
+    textMuted: "#676e95",
+    bgDeep: "#1b1e2e",
+    bgTabBar: "#1e2132",
+    selectionBg: "rgba(130,170,255,0.15)",
+    selectionRing: "rgba(130,170,255,0.4)",
+    dropTargetBg: "rgba(130,170,255,0.25)",
+    dropTargetRing: "#82aaff",
+    danger: "#ff5370",
+    dangerHover: "#ff6e88",
+    sidebarActive: "#82aaff",
+    sidebarActiveBg: "rgba(130,170,255,0.1)",
+    pathText: "#89ddff",
+    dirName: "#c792ea",
+    iconFolder: "#82aaff",
+    iconImage: "#c3e88d",
+    iconVideo: "#ff5370",
+    iconAudio: "#ffcb6b",
+    iconCode: "#89ddff",
+    iconJson: "#ffcb6b",
+    iconArchive: "#f78c6c",
+    iconText: "#8796b0",
+    iconDefault: "#676e95",
+  },
+  preview: ["#292d3e", "#82aaff", "#a6accd"],
+};

--- a/src/themes/rose-pine-dawn.ts
+++ b/src/themes/rose-pine-dawn.ts
@@ -1,0 +1,46 @@
+// Theme: Rosé Pine Dawn
+// Author: Rosé Pine
+// Source: https://github.com/rose-pine/rose-pine-theme
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const rosePineDawnTheme: Theme = {
+  id: "rose-pine-dawn",
+  name: "Rosé Pine Dawn",
+  nameJa: "Rosé Pine Dawn",
+  isDark: false,
+  colors: {
+    bg: "#faf4ed",
+    bgCard: "#fffaf3",
+    bgHover: "#f2e9e1",
+    border: "#dfdad9",
+    accent: "#907aa9",
+    accentLight: "#b4637a",
+    text: "#575279",
+    textDim: "#797593",
+    textMuted: "#9893a5",
+    bgDeep: "#f2e9e1",
+    bgTabBar: "#fffaf3",
+    selectionBg: "rgba(144,122,169,0.12)",
+    selectionRing: "rgba(144,122,169,0.35)",
+    dropTargetBg: "rgba(144,122,169,0.18)",
+    dropTargetRing: "#907aa9",
+    danger: "#b4637a",
+    dangerHover: "#d7827e",
+    sidebarActive: "#907aa9",
+    sidebarActiveBg: "rgba(144,122,169,0.08)",
+    pathText: "#56949f",
+    dirName: "#907aa9",
+    iconFolder: "#907aa9",
+    iconImage: "#286983",
+    iconVideo: "#b4637a",
+    iconAudio: "#ea9d34",
+    iconCode: "#56949f",
+    iconJson: "#ea9d34",
+    iconArchive: "#d7827e",
+    iconText: "#797593",
+    iconDefault: "#9893a5",
+  },
+  preview: ["#faf4ed", "#907aa9", "#575279"],
+};

--- a/src/themes/rose-pine-moon.ts
+++ b/src/themes/rose-pine-moon.ts
@@ -1,0 +1,46 @@
+// Theme: Rosé Pine Moon
+// Author: Rosé Pine
+// Source: https://github.com/rose-pine/rose-pine-theme
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const rosePineMoonTheme: Theme = {
+  id: "rose-pine-moon",
+  name: "Rosé Pine Moon",
+  nameJa: "Rosé Pine Moon",
+  isDark: true,
+  colors: {
+    bg: "#232136",
+    bgCard: "#2a273f",
+    bgHover: "#393552",
+    border: "#44415a",
+    accent: "#c4a7e7",
+    accentLight: "#ea9a97",
+    text: "#e0def4",
+    textDim: "#908caa",
+    textMuted: "#6e6a86",
+    bgDeep: "#232136",
+    bgTabBar: "#2a273f",
+    selectionBg: "rgba(196,167,231,0.15)",
+    selectionRing: "rgba(196,167,231,0.4)",
+    dropTargetBg: "rgba(196,167,231,0.25)",
+    dropTargetRing: "#c4a7e7",
+    danger: "#eb6f92",
+    dangerHover: "#f08aaa",
+    sidebarActive: "#c4a7e7",
+    sidebarActiveBg: "rgba(196,167,231,0.1)",
+    pathText: "#9ccfd8",
+    dirName: "#c4a7e7",
+    iconFolder: "#c4a7e7",
+    iconImage: "#3e8fb0",
+    iconVideo: "#eb6f92",
+    iconAudio: "#f6c177",
+    iconCode: "#9ccfd8",
+    iconJson: "#f6c177",
+    iconArchive: "#ea9a97",
+    iconText: "#908caa",
+    iconDefault: "#6e6a86",
+  },
+  preview: ["#232136", "#c4a7e7", "#e0def4"],
+};

--- a/src/themes/rose-pine.ts
+++ b/src/themes/rose-pine.ts
@@ -1,0 +1,46 @@
+// Theme: Rosé Pine
+// Author: Rosé Pine
+// Source: https://github.com/rose-pine/rose-pine-theme
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const rosePineTheme: Theme = {
+  id: "rose-pine",
+  name: "Rosé Pine",
+  nameJa: "Rosé Pine",
+  isDark: true,
+  colors: {
+    bg: "#191724",
+    bgCard: "#1f1d2e",
+    bgHover: "#26233a",
+    border: "#403d52",
+    accent: "#c4a7e7",
+    accentLight: "#ebbcba",
+    text: "#e0def4",
+    textDim: "#908caa",
+    textMuted: "#6e6a86",
+    bgDeep: "#191724",
+    bgTabBar: "#1f1d2e",
+    selectionBg: "rgba(196,167,231,0.15)",
+    selectionRing: "rgba(196,167,231,0.4)",
+    dropTargetBg: "rgba(196,167,231,0.25)",
+    dropTargetRing: "#c4a7e7",
+    danger: "#eb6f92",
+    dangerHover: "#f08aaa",
+    sidebarActive: "#c4a7e7",
+    sidebarActiveBg: "rgba(196,167,231,0.1)",
+    pathText: "#9ccfd8",
+    dirName: "#c4a7e7",
+    iconFolder: "#c4a7e7",
+    iconImage: "#31748f",
+    iconVideo: "#eb6f92",
+    iconAudio: "#f6c177",
+    iconCode: "#9ccfd8",
+    iconJson: "#f6c177",
+    iconArchive: "#ebbcba",
+    iconText: "#908caa",
+    iconDefault: "#6e6a86",
+  },
+  preview: ["#191724", "#c4a7e7", "#e0def4"],
+};

--- a/src/themes/solarized-dark.ts
+++ b/src/themes/solarized-dark.ts
@@ -1,3 +1,8 @@
+// Theme: Solarized Dark
+// Author: Ethan Schoonover
+// Source: https://github.com/altercation/solarized
+// License: MIT
+
 import type { Theme } from "../types";
 
 export const solarizedDarkTheme: Theme = {

--- a/src/themes/solarized-light.ts
+++ b/src/themes/solarized-light.ts
@@ -1,3 +1,8 @@
+// Theme: Solarized Light
+// Author: Ethan Schoonover
+// Source: https://github.com/altercation/solarized
+// License: MIT
+
 import type { Theme } from "../types";
 
 export const solarizedLightTheme: Theme = {

--- a/src/themes/synthwave-84.ts
+++ b/src/themes/synthwave-84.ts
@@ -1,0 +1,46 @@
+// Theme: Synthwave '84
+// Author: Robb Owen
+// Source: https://github.com/robb0wen/synthwave-vscode
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const synthwave84Theme: Theme = {
+  id: "synthwave-84",
+  name: "Synthwave '84",
+  nameJa: "Synthwave '84",
+  isDark: true,
+  colors: {
+    bg: "#262335",
+    bgCard: "#241b2f",
+    bgHover: "#34294f",
+    border: "#495495",
+    accent: "#f97e72",
+    accentLight: "#ff7edb",
+    text: "#ffffff",
+    textDim: "#bbbbbb",
+    textMuted: "#848bbd",
+    bgDeep: "#1e1a2e",
+    bgTabBar: "#241b2f",
+    selectionBg: "rgba(249,126,114,0.15)",
+    selectionRing: "rgba(249,126,114,0.4)",
+    dropTargetBg: "rgba(249,126,114,0.25)",
+    dropTargetRing: "#f97e72",
+    danger: "#fe4450",
+    dangerHover: "#ff6b6b",
+    sidebarActive: "#ff7edb",
+    sidebarActiveBg: "rgba(255,126,219,0.1)",
+    pathText: "#72f1b8",
+    dirName: "#ff7edb",
+    iconFolder: "#fede5d",
+    iconImage: "#72f1b8",
+    iconVideo: "#fe4450",
+    iconAudio: "#fede5d",
+    iconCode: "#36f9f6",
+    iconJson: "#fede5d",
+    iconArchive: "#f97e72",
+    iconText: "#bbbbbb",
+    iconDefault: "#848bbd",
+  },
+  preview: ["#262335", "#ff7edb", "#ffffff"],
+};

--- a/src/themes/tokyo-night.ts
+++ b/src/themes/tokyo-night.ts
@@ -1,0 +1,46 @@
+// Theme: Tokyo Night
+// Author: Enkelondon
+// Source: https://github.com/tokyo-night/tokyo-night-vscode-theme
+// License: MIT
+
+import type { Theme } from "../types";
+
+export const tokyoNightTheme: Theme = {
+  id: "tokyo-night",
+  name: "Tokyo Night",
+  nameJa: "Tokyo Night",
+  isDark: true,
+  colors: {
+    bg: "#1a1b26",
+    bgCard: "#16161e",
+    bgHover: "#292e42",
+    border: "#3b4261",
+    accent: "#7aa2f7",
+    accentLight: "#89b4fa",
+    text: "#c0caf5",
+    textDim: "#a9b1d6",
+    textMuted: "#565f89",
+    bgDeep: "#13131e",
+    bgTabBar: "#16161e",
+    selectionBg: "rgba(122,162,247,0.2)",
+    selectionRing: "rgba(122,162,247,0.5)",
+    dropTargetBg: "rgba(122,162,247,0.3)",
+    dropTargetRing: "#7aa2f7",
+    danger: "#f7768e",
+    dangerHover: "#ff9e9e",
+    sidebarActive: "#7aa2f7",
+    sidebarActiveBg: "rgba(122,162,247,0.1)",
+    pathText: "#73daca",
+    dirName: "#bb9af7",
+    iconFolder: "#7aa2f7",
+    iconImage: "#9ece6a",
+    iconVideo: "#f7768e",
+    iconAudio: "#e0af68",
+    iconCode: "#73daca",
+    iconJson: "#e0af68",
+    iconArchive: "#ff9e64",
+    iconText: "#a9b1d6",
+    iconDefault: "#565f89",
+  },
+  preview: ["#1a1b26", "#7aa2f7", "#c0caf5"],
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,10 +31,30 @@ export type ThemeId =
   | "default"
   | "dracula"
   | "catppuccin-mocha"
+  | "catppuccin-latte"
+  | "catppuccin-frappe"
+  | "catppuccin-macchiato"
   | "nord"
   | "solarized-dark"
   | "solarized-light"
-  | "one-dark";
+  | "one-dark"
+  | "atom-one-light"
+  | "tokyo-night"
+  | "gruvbox-dark"
+  | "gruvbox-light"
+  | "github-dark"
+  | "github-light"
+  | "rose-pine"
+  | "rose-pine-moon"
+  | "rose-pine-dawn"
+  | "everforest"
+  | "kanagawa"
+  | "ayu-dark"
+  | "ayu-light"
+  | "ayu-mirage"
+  | "palenight"
+  | "synthwave-84"
+  | "horizon";
 
 export interface ThemeColors {
   // Base


### PR DESCRIPTION
## Summary
- 20テーマを新規追加（合計27テーマに）
- 既存6テーマに Author / Source / License の Attribution コメントを追記
- `CREDITS.md` を作成し全テーマの出典を一覧化

## 追加テーマ
**ダーク (12):** Tokyo Night, Gruvbox Dark, GitHub Dark, Rosé Pine, Rosé Pine Moon, Everforest, Kanagawa, Ayu Dark, Ayu Mirage, Palenight, Synthwave '84, Horizon

**ミッドトーン (2):** Catppuccin Frappé, Catppuccin Macchiato

**ライト (6):** Gruvbox Light, GitHub Light, Rosé Pine Dawn, Ayu Light, Atom One Light, Catppuccin Latte

全テーマ MIT または MIT 互換ライセンス確認済み。

## Test plan
- [x] `bun run test` — 116テスト全合格
- [ ] `bun run tauri dev` で全27テーマの切り替えが即時反映されることを確認
- [ ] ライトテーマ7種のコントラストを確認