### PR TITLE
fix: 設定画面のサイズがウィンドウサイズに依存して崩れる

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -77,7 +77,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         onKeyDown={(e) => {
           if (e.key === "Escape") onClose();
         }}
-        className="bg-[var(--color-bg-card)] rounded-xl w-[800px] h-[520px] flex flex-col shadow-2xl shadow-black/40 animate-[dialog-in_200ms_ease-out] outline-none"
+        className="bg-[var(--color-bg-card)] rounded-xl w-[800px] max-w-[90vw] h-[520px] max-h-[85vh] flex flex-col shadow-2xl shadow-black/40 animate-[dialog-in_200ms_ease-out] outline-none"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
## Summary
- 設定ダイアログに `max-w-[90vw]` と `max-h-[85vh]` を追加
- ウィンドウが小さい場合（640×480等）でもダイアログがはみ出さなくなる
- 大きいウィンドウでは従来通り 800×520 で表示

closes #42