### PR TITLE
feat: ウィンドウ・ターミナルペインの半透明化 (v0.1.6)

### DIFF
--- a/e2e/transparency.spec.ts
+++ b/e2e/transparency.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  // localStorage をクリアしてデフォルト設定で開始
+  await page.evaluate(() => localStorage.removeItem("tauri-filer-ui-settings"));
+  await page.reload();
+});
+
+/** 設定ダイアログを開いて透明化トグルを返すヘルパー */
+async function openSettingsAndGetSwitch(page: import("@playwright/test").Page) {
+  await page.locator("button[title='設定'], button[title='Settings']").click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  const toggle = dialog.locator("button[aria-label='Window transparency']");
+  await expect(toggle).toBeVisible();
+  return { dialog, toggle };
+}
+
+/** --color-bg を取得 */
+function getCssVar(page: import("@playwright/test").Page, varName: string) {
+  return page.evaluate(
+    (v) => getComputedStyle(document.documentElement).getPropertyValue(v).trim(),
+    varName,
+  );
+}
+
+test("html/body/#root の背景が transparent", async ({ page }) => {
+  const results = await page.evaluate(() => {
+    const bg = (el: Element | null) =>
+      el ? getComputedStyle(el).backgroundColor : "";
+    return {
+      html: bg(document.documentElement),
+      body: bg(document.body),
+      root: bg(document.getElementById("root")),
+    };
+  });
+  // transparent は computedStyle では rgba(0, 0, 0, 0)
+  expect(results.html).toBe("rgba(0, 0, 0, 0)");
+  expect(results.body).toBe("rgba(0, 0, 0, 0)");
+  expect(results.root).toBe("rgba(0, 0, 0, 0)");
+});
+
+test("透明化ON → --color-bg が rgba になり、-solid に hex が残る", async ({
+  page,
+}) => {
+  const { toggle } = await openSettingsAndGetSwitch(page);
+
+  // 初期状態: OFF
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+  const bgBefore = await getCssVar(page, "--color-bg");
+  expect(bgBefore).toBe("#0a0a0f");
+
+  // 透明化 ON
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+
+  // --color-bg → rgba(10, 10, 15, 0.8)（デフォルト opacity 80%）
+  const bgAfter = await getCssVar(page, "--color-bg");
+  expect(bgAfter).toBe("rgba(10, 10, 15, 0.8)");
+
+  // --color-bg-solid に元の hex が保持されている
+  const bgSolid = await getCssVar(page, "--color-bg-solid");
+  expect(bgSolid).toBe("#0a0a0f");
+});
+
+test("不透明度スライダーで rgba の alpha が変化する", async ({ page }) => {
+  const { dialog, toggle } = await openSettingsAndGetSwitch(page);
+
+  // 透明化 ON → スライダーが出現
+  await toggle.click();
+  const slider = dialog.locator("input[type='range']");
+  await expect(slider).toBeVisible();
+
+  // スライダー値を 50 に変更
+  await slider.fill("50");
+
+  // alpha が 0.5 になる
+  const bgColor = await getCssVar(page, "--color-bg");
+  expect(bgColor).toBe("rgba(10, 10, 15, 0.5)");
+});
+
+test("透明化OFF → --color-bg が hex に戻る", async ({ page }) => {
+  const { toggle } = await openSettingsAndGetSwitch(page);
+
+  await toggle.click(); // ON
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+
+  await toggle.click(); // OFF
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+
+  const bgColor = await getCssVar(page, "--color-bg");
+  expect(bgColor).toBe("#0a0a0f");
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-filer",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "description": "Cross-platform desktop file manager built with Tauri 2 + React 19",
   "author": "win-chanma",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -431,9 +431,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -695,9 +695,9 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
@@ -1809,9 +1809,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1926,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2155,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
  "objc2-exception-helper",
@@ -2983,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -3056,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -3264,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3283,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-filer"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -4027,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
@@ -4604,9 +4604,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4617,9 +4617,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4631,9 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4641,9 +4641,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4654,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]
@@ -4710,9 +4710,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5498,9 +5498,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.13.2"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -5533,9 +5533,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.13.2"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5639,9 +5639,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.9.2"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
 dependencies = [
  "endi",
  "enumflags2",
@@ -5653,9 +5653,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.9.2"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-filer"
-version = "0.1.5"
+version = "0.1.6"
 description = "Desktop File Manager"
 authors = ["win-chanma"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tauri Filer",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.win.tauri-filer",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -16,7 +16,9 @@
         "width": 1100,
         "height": 700,
         "minWidth": 640,
-        "minHeight": 480
+        "minHeight": 480,
+        "transparent": true,
+        "shadow": false
       }
     ],
     "security": {

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -39,6 +39,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const setTerminalFontSize = useUIStore((s) => s.setTerminalFontSize);
   const terminalPadding = useUIStore((s) => s.terminalPadding);
   const setTerminalPadding = useUIStore((s) => s.setTerminalPadding);
+  const windowTransparency = useUIStore((s) => s.windowTransparency);
+  const setWindowTransparency = useUIStore((s) => s.setWindowTransparency);
+  const windowOpacity = useUIStore((s) => s.windowOpacity);
+  const setWindowOpacity = useUIStore((s) => s.setWindowOpacity);
   const dialogRef = useRef<HTMLDivElement>(null);
   const [activeSection, setActiveSection] = useState<SectionId>("display");
 
@@ -89,7 +93,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         onKeyDown={(e) => {
           if (e.key === "Escape") onClose();
         }}
-        className="bg-[var(--color-bg-card)] rounded-xl w-[800px] max-w-[90vw] h-[520px] max-h-[85vh] flex flex-col shadow-2xl shadow-black/40 animate-[dialog-in_200ms_ease-out] outline-none"
+        className="bg-[var(--color-bg-card-solid)] rounded-xl w-[800px] max-w-[90vw] h-[520px] max-h-[85vh] flex flex-col shadow-2xl shadow-black/40 animate-[dialog-in_200ms_ease-out] outline-none"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
@@ -177,6 +181,40 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                     />
                   </SegmentedControl>
                 </SettingRow>
+
+                <SettingRow
+                  label={t("settings.windowTransparency")}
+                  description={t("settings.windowTransparencyDesc")}
+                >
+                  <ToggleSwitch
+                    checked={windowTransparency}
+                    onChange={() => setWindowTransparency(!windowTransparency)}
+                    aria-label="Window transparency"
+                  />
+                </SettingRow>
+
+                {windowTransparency && (
+                  <SettingRow
+                    label={t("settings.windowOpacity")}
+                    description={t("settings.windowOpacityDesc")}
+                  >
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="range"
+                        min={30}
+                        max={100}
+                        value={windowOpacity}
+                        onChange={(e) =>
+                          setWindowOpacity(parseInt(e.target.value, 10))
+                        }
+                        className="w-[120px] accent-[var(--color-accent)]"
+                      />
+                      <span className="text-[13px] font-medium text-[var(--color-text)] w-[36px] text-right tabular-nums">
+                        {windowOpacity}%
+                      </span>
+                    </div>
+                  </SettingRow>
+                )}
               </SettingsPane>
             )}
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -106,4 +106,10 @@ export const en = {
   "settings.terminalFontSizeDesc": "Set the terminal font size",
   "settings.terminalPadding": "Inner padding",
   "settings.terminalPaddingDesc": "Set the padding inside the terminal area (px)",
+
+  // Settings - Display (transparency)
+  "settings.windowTransparency": "Window transparency",
+  "settings.windowTransparencyDesc": "Make the window background semi-transparent",
+  "settings.windowOpacity": "Opacity",
+  "settings.windowOpacityDesc": "Adjust the background opacity (30–100%)",
 } as const;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -106,4 +106,10 @@ export const ja = {
   "settings.terminalFontSizeDesc": "ターミナルのフォントサイズを設定します",
   "settings.terminalPadding": "内側の余白",
   "settings.terminalPaddingDesc": "ターミナル描画エリアの内側余白を設定します（px）",
+
+  // Settings - Display (transparency)
+  "settings.windowTransparency": "ウィンドウの透明化",
+  "settings.windowTransparencyDesc": "ウィンドウ背景を半透明にしてデスクトップを透かします",
+  "settings.windowOpacity": "不透明度",
+  "settings.windowOpacityDesc": "背景の不透明度を調整します（30〜100%）",
 } as const;

--- a/src/index.css
+++ b/src/index.css
@@ -43,10 +43,10 @@
 html, body, #root {
   height: 100%;
   overflow: hidden;
+  background: transparent;
 }
 
 body {
-  background: var(--color-bg);
   color: var(--color-text);
   font-family: 'Inter', 'Noto Sans JP', -apple-system, BlinkMacSystemFont, sans-serif;
 }

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -14,6 +14,8 @@ interface UISettings {
   terminalShellPath: string;
   terminalFontSize: number;
   terminalPadding: number;
+  windowTransparency: boolean;
+  windowOpacity: number;
 }
 
 interface UIStore extends UISettings {
@@ -26,6 +28,8 @@ interface UIStore extends UISettings {
   setTerminalShellPath: (path: string) => void;
   setTerminalFontSize: (size: number) => void;
   setTerminalPadding: (padding: number) => void;
+  setWindowTransparency: (enabled: boolean) => void;
+  setWindowOpacity: (opacity: number) => void;
 }
 
 const STORAGE_KEY = "tauri-filer-ui-settings";
@@ -53,6 +57,8 @@ const defaults: UISettings = {
   terminalShellPath: "",
   terminalFontSize: 14,
   terminalPadding: 8,
+  windowTransparency: false,
+  windowOpacity: 80,
 };
 
 const initial: UISettings = { ...defaults, ...loadSettings() };
@@ -68,11 +74,16 @@ function getSettings(state: UIStore): UISettings {
     terminalShellPath: state.terminalShellPath,
     terminalFontSize: state.terminalFontSize,
     terminalPadding: state.terminalPadding,
+    windowTransparency: state.windowTransparency,
+    windowOpacity: state.windowOpacity,
   };
 }
 
 // Apply theme immediately on module load to prevent FOUC
-applyTheme(getTheme(initial.themeId));
+applyTheme(
+  getTheme(initial.themeId),
+  initial.windowTransparency ? initial.windowOpacity / 100 : undefined,
+);
 
 export const useUIStore = create<UIStore>((set, get) => ({
   ...initial,
@@ -99,7 +110,11 @@ export const useUIStore = create<UIStore>((set, get) => ({
   setTheme: (themeId) => {
     set({ themeId });
     saveSettings(getSettings(get()));
-    applyTheme(getTheme(themeId));
+    const s = get();
+    applyTheme(
+      getTheme(themeId),
+      s.windowTransparency ? s.windowOpacity / 100 : undefined,
+    );
   },
   toggleTerminal: () => {
     set((s) => ({ terminalVisible: !s.terminalVisible }));
@@ -116,5 +131,23 @@ export const useUIStore = create<UIStore>((set, get) => ({
   setTerminalPadding: (padding) => {
     set({ terminalPadding: padding });
     saveSettings(getSettings(get()));
+  },
+  setWindowTransparency: (enabled) => {
+    set({ windowTransparency: enabled });
+    saveSettings(getSettings(get()));
+    const s = get();
+    applyTheme(
+      getTheme(s.themeId),
+      enabled ? s.windowOpacity / 100 : undefined,
+    );
+  },
+  setWindowOpacity: (opacity) => {
+    set({ windowOpacity: opacity });
+    saveSettings(getSettings(get()));
+    const s = get();
+    applyTheme(
+      getTheme(s.themeId),
+      s.windowTransparency ? opacity / 100 : undefined,
+    );
   },
 }));

--- a/src/themes/apply-theme.ts
+++ b/src/themes/apply-theme.ts
@@ -33,10 +33,73 @@ const VAR_MAP: Record<string, string> = {
   iconDefault: "--color-icon-default",
 };
 
-export function applyTheme(theme: Theme): void {
+const BG_KEYS = new Set(["bg", "bgCard", "bgHover", "bgDeep", "bgTabBar"]);
+
+export function hexToRgba(hex: string, alpha: number): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.substring(0, 2), 16);
+  const g = parseInt(h.substring(2, 4), 16);
+  const b = parseInt(h.substring(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function parseHex(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [
+    parseInt(h.substring(0, 2), 16),
+    parseInt(h.substring(2, 4), 16),
+    parseInt(h.substring(4, 6), 16),
+  ];
+}
+
+function relativeBgOverlay(
+  base: string,
+  target: string,
+): string {
+  const [br, bg, bb] = parseHex(base);
+  const [tr, tg, tb] = parseHex(target);
+  const dr = tr - br;
+  const dg = tg - bg;
+  const db = tb - bb;
+  const avg = (dr + dg + db) / 3;
+  if (avg >= 0) {
+    // target が base より明るい → 白の薄い overlay
+    const a = Math.min(Math.round(Math.abs(avg) / 255 * 100) / 100, 0.15);
+    return `rgba(255, 255, 255, ${Math.max(a, 0.02)})`;
+  } else {
+    // target が base より暗い → 黒の薄い overlay
+    const a = Math.min(Math.round(Math.abs(avg) / 255 * 100) / 100, 0.15);
+    return `rgba(0, 0, 0, ${Math.max(a, 0.02)})`;
+  }
+}
+
+export function applyTheme(theme: Theme, opacity?: number): void {
   const root = document.documentElement;
   const colors = theme.colors;
+  const baseBg = colors.bg;
+
   for (const [key, cssVar] of Object.entries(VAR_MAP)) {
-    root.style.setProperty(cssVar, colors[key as keyof typeof colors]);
+    const value = colors[key as keyof typeof colors];
+
+    if (opacity !== undefined && BG_KEYS.has(key) && value.startsWith("#")) {
+      // 常に solid 版を保持
+      root.style.setProperty(`${cssVar}-solid`, value);
+
+      if (key === "bg") {
+        // ルート背景のみ本体の rgba 不透明度を持つ
+        root.style.setProperty(cssVar, hexToRgba(value, opacity));
+      } else if (key === "bgHover") {
+        // hover は白の薄い overlay
+        root.style.setProperty(cssVar, "rgba(255, 255, 255, 0.08)");
+      } else {
+        // 内側コンポーネントは、ルートからの相対差分を薄い overlay で表現
+        root.style.setProperty(cssVar, relativeBgOverlay(baseBg, value));
+      }
+    } else {
+      root.style.setProperty(cssVar, value);
+      if (BG_KEYS.has(key)) {
+        root.style.setProperty(`${cssVar}-solid`, value);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #58

- `shadow: false` を追加し、Tauri v2 のデフォルト shadow が `transparent: true` と競合する問題を修正
- `windowEffects: ["mica"]` を削除（不透明な Mica レイヤーが透過を完全に上書きしていたため）
- CSS の `!important` / `color-scheme: normal !important` ハックを削除（shadow: false で根本解決）
- 透過ON時は xterm.js WebGL レンダラーを dispose し Canvas フォールバックに切替（WebGL は `allowTransparency` 非対応でリサイズ時に不透明化するため）
- 透過OFF時は WebGL を再ロードして GPU アクセラレーションを維持
- E2E テスト 4 件追加（透過ON/OFF、スライダー、CSS変数検証）

## Test plan

- [x] `tsc --noEmit` 型チェック通過
- [x] `bun run test` ユニットテスト 206 件通過
- [x] `npx playwright test` E2E テスト 21 件通過（新規4件含む）
- [x] `bun run tauri dev` で実機確認 — 透過ON時にデスクトップが透けて見えることを確認
- [x] ターミナルペインのリサイズで透過が崩れないことを確認