### PR TITLE
fix: updater 公開鍵更新 + createUpdaterArtifacts 有効化

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,11 +33,12 @@
       "endpoints": [
         "https://github.com/win-chanma/tauri-filer/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENBQjg2QjE5MTcwOTIxNzUKUldSMUlRa1hHV3U0eXBaUTZSaGJKejN2NkhFMWo0eVB3N0FmN2NjeWJGYldoeng0bGNFSGdpQlAK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY3NEUzNzY3RTBFMENEQjQKUldTMHplRGdaemRPWjFNc2JXNWNwelUydHlZa2N6QnBZOWtXWCs4eXBPbisxVDU4VHcwSDMxNWwK"
     }
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": "v1Compatible",
     "targets": "all",
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
- 署名鍵を再生成したため pubkey を更新
- `bundle.createUpdaterArtifacts: "v1Compatible"` を追加（`.sig` ファイル生成に必要だった）

refs #66