### PR TITLE
fix: updater パーミッション追加

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
     "dialog:allow-confirm",
     "shell:default",
     "shell:allow-open",
+    "updater:default",
     {
       "identifier": "fs:scope",
       "allow": [

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -21,8 +21,8 @@ export function UpdateNotification() {
           setState("available");
         }
       })
-      .catch(() => {
-        // silently ignore update check failures
+      .catch((err) => {
+        console.error("[updater] check failed:", err);
       });
   }, []);
 


### PR DESCRIPTION
## Summary
- `capabilities/default.json` に `updater:default` を追加（更新チェックに必要）
- UpdateNotification のエラーハンドリングを改善（console.error でログ出力）

refs #66