### PR TITLE
fix: release ワークフローに署名鍵を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,8 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- `tauri-action` に `TAURI_SIGNING_PRIVATE_KEY` / `PASSWORD` を渡すよう修正
- これにより `git tag v*` → push で自動ビルド・署名・リリースが完結する

refs #66