### PR TITLE
chore: バンドルターゲットを絞る

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
   "bundle": {
     "active": true,
     "createUpdaterArtifacts": "v1Compatible",
-    "targets": "all",
+    "targets": ["nsis", "dmg", "app", "appimage", "deb"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
nsis/dmg/app/appimage/deb のみに変更。msi/rpm を除外