### PR TITLE
fix: WebView2初期化後にアイコンが上書きされる問題を修正 refs #75

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-show",
+    "core:window:allow-set-icon",
     "opener:default",
     "opener:allow-open-path",
     "fs:default",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,11 @@ import { AppLayout } from "./components/AppLayout";
 function App() {
   useEffect(() => {
     try {
-      getCurrentWindow().show().catch(() => {});
+      const win = getCurrentWindow();
+      win
+        .show()
+        .then(() => win.setIcon("icons/icon.png"))
+        .catch(() => {});
     } catch {
       // not in Tauri context (e.g. Playwright tests)
     }


### PR DESCRIPTION
## Summary

- `show()` 後に `setIcon()` を呼んでカスタムアイコンを定着させる
- `core:window:allow-set-icon` パーミッション追加

## 背景

Rust の setup フックでアイコンを設定しても、WebView2 の初期化完了時に上書きされてしまう。
フロントエンド側からも設定することで維持される。

## Test plan

- [x] vitest 222 テスト pass
- [x] Playwright 10 テスト pass
- [x] `bun run tauri dev` で起動確認済み — アイコンが維持される