### PR TITLE
fix: リリースビルドでタスクバーアイコンがデフォルトに戻る問題を修正 refs #75

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,7 +6,6 @@
   "permissions": [
     "core:default",
     "core:window:allow-show",
-    "core:window:allow-set-icon",
     "opener:default",
     "opener:allow-open-path",
     "fs:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,6 @@ mod models;
 mod terminal;
 
 use commands::*;
-use tauri::Manager;
 use terminal::PtyManager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -15,13 +14,10 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(PtyManager::new())
-        .setup(|app| {
+        .on_page_load(|webview, _payload| {
             if let Ok(icon) = tauri::image::Image::from_bytes(include_bytes!("../icons/icon.png")) {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.set_icon(icon);
-                }
+                let _ = webview.window().set_icon(icon);
             }
-            Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             read_directory,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,7 @@ import { AppLayout } from "./components/AppLayout";
 function App() {
   useEffect(() => {
     try {
-      const win = getCurrentWindow();
-      win
-        .show()
-        .then(() => win.setIcon("icons/icon.png"))
-        .catch(() => {});
+      getCurrentWindow().show().catch(() => {});
     } catch {
       // not in Tauri context (e.g. Playwright tests)
     }


### PR DESCRIPTION
## Summary

- JS側 `setIcon(path)` を削除（リリースビルドでパス解決不可）
- Rust側 `on_page_load` で WebView 読み込み完了後にアイコン設定
- `include_bytes!` でバイナリ埋め込みのためパス問題なし

## Test plan

- [x] vitest 222 pass / Playwright 10 pass
- [x] `bun run tauri dev` でアイコン維持確認済み