### PR TITLE
perf: 起動速度改善 + shell open 修正 + v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-filer",
   "private": true,
-  "version": "0.1.9",
+  "version": "0.2.0",
   "type": "module",
   "description": "Cross-platform desktop file manager built with Tauri 2 + React 19",
   "author": "win-chanma",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-filer"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-filer"
-version = "0.1.9"
+version = "0.2.0"
 description = "Desktop File Manager"
 authors = ["win-chanma"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tauri Filer",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "identifier": "com.win.tauri-filer",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -28,7 +28,7 @@
   },
   "plugins": {
     "shell": {
-      "open": "^([A-Za-z]:\\\\|/)"
+      "open": "([A-Za-z]:\\\\|/).*"
     },
     "updater": {
       "endpoints": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,7 @@
-import { useEffect } from "react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { AppLayout } from "./components/AppLayout";
 
 function App() {
-  useEffect(() => {
-    try {
-      getCurrentWindow().show().catch(() => {});
-    } catch {
-      // not in Tauri context (e.g. Playwright tests)
-    }
-  }, []);
-
   return (
     <ErrorBoundary>
       <AppLayout />

--- a/src/commands/fs-commands.ts
+++ b/src/commands/fs-commands.ts
@@ -6,8 +6,12 @@ export async function readDirectory(path: string): Promise<FileEntry[]> {
   return invoke<FileEntry[]>("read_directory", { path });
 }
 
+let homeDirCache: string | null = null;
+
 export async function getHomeDir(): Promise<string> {
-  return invoke<string>("get_home_dir");
+  if (homeDirCache) return homeDirCache;
+  homeDirCache = await invoke<string>("get_home_dir");
+  return homeDirCache;
 }
 
 export async function copyItems(

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useRef, lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useTabStore } from "../stores/tab-store";
 import { useFileStore } from "../stores/file-store";
 import { useUIStore } from "../stores/ui-store";
@@ -22,22 +23,22 @@ import { useMouseNavigation } from "../hooks/use-mouse-navigation";
 import { TabBar } from "./TabBar";
 import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
-import { ListView } from "./ListView";
-import { GridView } from "./GridView";
 import { StatusBar } from "./StatusBar";
 import { ContextMenu } from "./ContextMenu";
-import { NewFolderDialog } from "./NewFolderDialog";
-import { RenameDialog } from "./RenameDialog";
-import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
-import { SearchDialog } from "./SearchDialog";
-import { FilePreviewDialog } from "./FilePreviewDialog";
 import { EmptyState } from "./EmptyState";
-import { UpdateNotification } from "./UpdateNotification";
 import { Spinner } from "./Spinner";
 import type { FileEntry } from "../types";
 
+const ListView = lazy(() => import("./ListView").then((m) => ({ default: m.ListView })));
+const GridView = lazy(() => import("./GridView").then((m) => ({ default: m.GridView })));
 const TerminalPane = lazy(() => import("./TerminalPane").then((m) => ({ default: m.TerminalPane })));
 const SettingsDialog = lazy(() => import("./SettingsDialog").then((m) => ({ default: m.SettingsDialog })));
+const NewFolderDialog = lazy(() => import("./NewFolderDialog").then((m) => ({ default: m.NewFolderDialog })));
+const RenameDialog = lazy(() => import("./RenameDialog").then((m) => ({ default: m.RenameDialog })));
+const DeleteConfirmDialog = lazy(() => import("./DeleteConfirmDialog").then((m) => ({ default: m.DeleteConfirmDialog })));
+const SearchDialog = lazy(() => import("./SearchDialog").then((m) => ({ default: m.SearchDialog })));
+const FilePreviewDialog = lazy(() => import("./FilePreviewDialog").then((m) => ({ default: m.FilePreviewDialog })));
+const UpdateNotification = lazy(() => import("./UpdateNotification").then((m) => ({ default: m.UpdateNotification })));
 
 export function AppLayout() {
   const { t } = useTranslation();
@@ -125,17 +126,30 @@ export function AppLayout() {
   );
 
   useEffect(() => {
+    const showWindow = () => {
+      try {
+        getCurrentWindow().show().catch(() => {});
+      } catch {
+        // not in Tauri context
+      }
+    };
+
     if (tabs.length === 0) {
       getHomeDir()
         .then((home) => {
           addTab(home);
           return loadDirectory(home);
         })
+        .then(() => showWindow())
         .catch((err) => {
           console.error("Init failed:", err);
           addTab("/");
-          loadDirectory("/").catch(console.error);
+          loadDirectory("/")
+            .then(() => showWindow())
+            .catch(() => showWindow());
         });
+    } else {
+      showWindow();
     }
   }, []);
 
@@ -190,7 +204,9 @@ export function AppLayout() {
     <div className="flex flex-col h-screen bg-[var(--color-bg)] text-[var(--color-text)]">
       <TabBar />
       <Toolbar onSettingsOpen={() => setSettingsOpen(true)} />
-      <UpdateNotification />
+      <Suspense fallback={null}>
+        <UpdateNotification />
+      </Suspense>
       <div className="flex flex-1 min-h-0">
         {sidebarVisible && <Sidebar />}
         <main className="flex-1 min-w-0 flex flex-col">
@@ -202,9 +218,11 @@ export function AppLayout() {
           )}
           {!loading && !error && entries.length === 0 && <EmptyState />}
           {!loading && !error && entries.length > 0 && (
-            viewMode === "list"
-              ? <ListView onContextMenu={showContextMenu} onFileOpen={handleFileOpen} />
-              : <GridView onContextMenu={showContextMenu} onFileOpen={handleFileOpen} />
+            <Suspense fallback={null}>
+              {viewMode === "list"
+                ? <ListView onContextMenu={showContextMenu} onFileOpen={handleFileOpen} />
+                : <GridView onContextMenu={showContextMenu} onFileOpen={handleFileOpen} />}
+            </Suspense>
           )}
         </main>
         {terminalVisible && (
@@ -235,32 +253,52 @@ export function AppLayout() {
         onClose={hideContextMenu}
         items={contextMenuItems}
       />
-      <NewFolderDialog
-        open={newFolderOpen}
-        onClose={() => setNewFolderOpen(false)}
-        onCreate={handleCreateFolder}
-      />
-      <RenameDialog
-        open={renameOpen}
-        currentName={selectedEntry?.name || ""}
-        onClose={() => setRenameOpen(false)}
-        onRename={handleRename}
-      />
-      <DeleteConfirmDialog
-        open={deleteOpen}
-        count={selectedPaths.size}
-        onClose={() => setDeleteOpen(false)}
-        onConfirm={handleDelete}
-      />
-      <SearchDialog
-        open={searchOpen}
-        onClose={() => setSearchOpen(false)}
-      />
-      <FilePreviewDialog
-        open={!!previewEntry}
-        entry={previewEntry}
-        onClose={() => setPreviewEntry(null)}
-      />
+      {newFolderOpen && (
+        <Suspense fallback={null}>
+          <NewFolderDialog
+            open={newFolderOpen}
+            onClose={() => setNewFolderOpen(false)}
+            onCreate={handleCreateFolder}
+          />
+        </Suspense>
+      )}
+      {renameOpen && (
+        <Suspense fallback={null}>
+          <RenameDialog
+            open={renameOpen}
+            currentName={selectedEntry?.name || ""}
+            onClose={() => setRenameOpen(false)}
+            onRename={handleRename}
+          />
+        </Suspense>
+      )}
+      {deleteOpen && (
+        <Suspense fallback={null}>
+          <DeleteConfirmDialog
+            open={deleteOpen}
+            count={selectedPaths.size}
+            onClose={() => setDeleteOpen(false)}
+            onConfirm={handleDelete}
+          />
+        </Suspense>
+      )}
+      {searchOpen && (
+        <Suspense fallback={null}>
+          <SearchDialog
+            open={searchOpen}
+            onClose={() => setSearchOpen(false)}
+          />
+        </Suspense>
+      )}
+      {previewEntry && (
+        <Suspense fallback={null}>
+          <FilePreviewDialog
+            open={!!previewEntry}
+            entry={previewEntry}
+            onClose={() => setPreviewEntry(null)}
+          />
+        </Suspense>
+      )}
       {settingsOpen && (
         <Suspense fallback={null}>
           <SettingsDialog

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,8 +4,16 @@ import "./i18n";
 import App from "./App";
 import "./index.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+const root = ReactDOM.createRoot(
+  document.getElementById("root") as HTMLElement,
 );
+
+if (import.meta.env.DEV) {
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+} else {
+  root.render(<App />);
+}

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -42,7 +42,8 @@ describe("tauri.conf.json セキュリティ設定", () => {
 
   describe("Shell plugin open パターン", () => {
     const pattern = tauriConf.plugins.shell.open;
-    const regex = new RegExp(pattern);
+    // Tauri は内部で ^..$ でラップするため、実際の挙動を再現する
+    const regex = new RegExp("^" + pattern + "$");
 
     it("パターンが .* (全許可) でないこと", () => {
       expect(pattern).not.toBe(".*");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,4 +24,14 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules/react-virtuoso")) return "virtuoso";
+          if (id.includes("node_modules/react-dom") || id.includes("node_modules/react/")) return "react-vendor";
+        },
+      },
+    },
+  },
 }));


### PR DESCRIPTION
## Summary
- メインバンドルを **379KB → 112KB** に削減（-70%）
  - ListView/GridView/ダイアログ系を lazy 化
  - react-virtuoso を vendor チャンクに分離
  - Vite manualChunks 設定追加
- `show()` をディレクトリ読み込み完了後に遅延（空画面/スピナーが見えなくなる）
- `React.StrictMode` を dev 環境のみに限定（本番での二重マウント排除）
- `getHomeDir` の結果をキャッシュ化（AppLayout + Sidebar の重複呼び出し排除）
- shell open スコープの正規表現を修正（Tauri の `^..$` ラップとの二重適用でファイルが開けなかった問題）
- `security.test.ts` で Tauri の regex ラップ動作を再現するよう修正

## Test plan
- [x] `bun run test` — 222 テスト全パス
- [x] `bunx tsc --noEmit` — 型チェックパス
- [x] `bun run build` — ビルド成功
- [x] Playwright スクリーンショットテスト — 10 テストパス
- [x] `bun run tauri dev` で起動確認 — 起動速度改善を体感確認
- [x] ファイルのダブルクリックで関連付けアプリが開くことを確認