### PR TITLE
fix: 更新チェック時のUIフリーズを解消

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 portable-pty = "0.8"
 tauri-plugin-updater = "2"
+ureq = { version = "2", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,5 @@
 pub mod fs_ops;
+pub mod updater;
 
 pub use fs_ops::*;
+pub use updater::*;

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,0 +1,39 @@
+const UPDATE_ENDPOINT: &str =
+    "https://github.com/win-chanma/tauri-filer/releases/latest/download/latest.json";
+
+#[tauri::command]
+pub fn check_update_version() -> Result<Option<String>, String> {
+    let current =
+        parse_semver(env!("CARGO_PKG_VERSION")).ok_or("Invalid current version")?;
+
+    let resp = ureq::get(UPDATE_ENDPOINT)
+        .call()
+        .map_err(|e| format!("HTTP error: {}", e))?;
+
+    let json: serde_json::Value = resp
+        .into_json()
+        .map_err(|e| format!("JSON error: {}", e))?;
+
+    let remote_str = json["version"]
+        .as_str()
+        .ok_or("Missing version in response")?
+        .trim_start_matches('v');
+
+    let remote = parse_semver(remote_str).ok_or("Invalid remote version")?;
+
+    if remote > current {
+        Ok(Some(remote_str.to_string()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn parse_semver(s: &str) -> Option<(u64, u64, u64)> {
+    let s = s.trim_start_matches('v');
+    let mut parts = s.splitn(3, '.');
+    Some((
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next()?.split('-').next()?.parse().ok()?,
+    ))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub fn run() {
             terminal::terminal_write,
             terminal::terminal_resize,
             terminal::terminal_kill,
+            check_update_version,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/commands/updater-commands.test.ts
+++ b/src/commands/updater-commands.test.ts
@@ -1,12 +1,34 @@
 import { describe, it, expect, vi } from "vitest";
 
 const mockCheck = vi.hoisted(() => vi.fn());
+const mockInvoke = vi.hoisted(() => vi.fn());
 
 vi.mock("@tauri-apps/plugin-updater", () => ({
   check: mockCheck,
 }));
 
-import { checkForUpdate } from "./updater-commands";
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+import { checkForUpdate, checkUpdateVersion } from "./updater-commands";
+
+describe("checkUpdateVersion", () => {
+  it("新しいバージョンがある場合バージョン文字列を返す", async () => {
+    mockInvoke.mockResolvedValue("0.3.0");
+
+    const result = await checkUpdateVersion();
+    expect(result).toBe("0.3.0");
+    expect(mockInvoke).toHaveBeenCalledWith("check_update_version");
+  });
+
+  it("更新がない場合 null を返す", async () => {
+    mockInvoke.mockResolvedValue(null);
+
+    const result = await checkUpdateVersion();
+    expect(result).toBeNull();
+  });
+});
 
 describe("checkForUpdate", () => {
   it("更新がある場合 Update オブジェクトを返す", async () => {

--- a/src/commands/updater-commands.ts
+++ b/src/commands/updater-commands.ts
@@ -1,7 +1,14 @@
+import { invoke } from "@tauri-apps/api/core";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 
 export type { Update };
 
+/** Lightweight version check via custom Rust command (no UI freeze) */
+export async function checkUpdateVersion(): Promise<string | null> {
+  return await invoke<string | null>("check_update_version");
+}
+
+/** Full updater check — only call when user wants to install */
 export async function checkForUpdate(): Promise<Update | null> {
   return await check();
 }

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -1,24 +1,22 @@
-import { useEffect, useRef, useState, memo } from "react";
+import { useEffect, useState, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { Download, RefreshCw, X } from "lucide-react";
-import { checkForUpdate, type Update } from "../commands/updater-commands";
+import { checkUpdateVersion, checkForUpdate } from "../commands/updater-commands";
 
 type UpdateState = "idle" | "available" | "downloading" | "ready";
 
 export const UpdateNotification = memo(function UpdateNotification() {
   const { t } = useTranslation();
   const [state, setState] = useState<UpdateState>("idle");
-  const updateRef = useRef<Update | null>(null);
   const [version, setVersion] = useState("");
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
     const scheduleCheck = () => {
-      checkForUpdate()
-        .then((u) => {
-          if (u) {
-            updateRef.current = u;
-            setVersion(u.version);
+      checkUpdateVersion()
+        .then((v) => {
+          if (v) {
+            setVersion(v);
             setState("available");
           }
         })
@@ -38,11 +36,16 @@ export const UpdateNotification = memo(function UpdateNotification() {
   }, []);
 
   async function handleUpdate() {
-    if (!updateRef.current) return;
     setState("downloading");
+    await new Promise((r) => requestAnimationFrame(r));
     try {
-      await updateRef.current.downloadAndInstall();
-      setState("ready");
+      const update = await checkForUpdate();
+      if (update) {
+        await update.downloadAndInstall();
+        setState("ready");
+      } else {
+        setState("available");
+      }
     } catch {
       setState("available");
     }


### PR DESCRIPTION
## Summary
- `tauri-plugin-updater` の `check()` がUIスレッドをブロックしてフリーズしていた問題を修正
- 軽量な独自Rustコマンド `check_update_version` を追加（`ureq` でHTTP取得 → バージョン比較のみ）
- Tauriのスレッドプールで実行されるため、WebViewのUIスレッドをブロックしない
- 重い `check()` + `downloadAndInstall()` はユーザーが「インストール」をクリックした時のみ呼び出し

## 変更内容
- `src-tauri/src/commands/updater.rs`: 新規 — `ureq` で endpoint JSON を取得し semver 比較
- `src/commands/updater-commands.ts`: `checkUpdateVersion()` 追加（軽量IPC）、`checkForUpdate()` はインストール用に維持
- `src/components/UpdateNotification.tsx`: 初期チェックに `checkUpdateVersion()` 使用、インストール時のみ `check()` 呼び出し

## Test plan
- [x] `cargo test` 全31テスト通過
- [x] `bun run test` 全222テスト通過（updater テスト5件含む）
- [x] `tsc --noEmit` 型チェック通過
- [x] Playwright スクリーンショットテスト通過
- [ ] v0.2.1インストール済み環境で更新通知がフリーズなしで表示されることを確認