### PR TITLE
fix: OSローディングカーソルを排除

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,7 +5,6 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "core:window:allow-show",
     "opener:default",
     "opener:allow-open-path",
     "fs:default",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
         "minHeight": 480,
         "transparent": true,
         "shadow": false,
-        "visible": false
+        "visible": true
       }
     ],
     "security": {

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, useCallback, useRef, lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useTabStore } from "../stores/tab-store";
 import { useFileStore } from "../stores/file-store";
 import { useUIStore } from "../stores/ui-store";
@@ -125,13 +124,6 @@ export function AppLayout() {
   );
 
   useEffect(() => {
-    // Show window immediately — skeleton UI is already visible
-    try {
-      getCurrentWindow().show().catch(() => {});
-    } catch {
-      // not in Tauri context
-    }
-
     if (tabs.length === 0) {
       getHomeDir()
         .then((home) => {


### PR DESCRIPTION
## Summary
- `visible: false` → `visible: true` に変更
- ウィンドウが即座に表示されるため、OSのローディングカーソル（ぐるぐる）が出なくなる
- index.html に既にダーク背景 (`#0a0a0f`) が設定済みなので白画面フラッシュなし
- 不要になった `show()` 呼び出しと `core:window:allow-show` パーミッションを削除

## 起動フロー
```
Before: [プロセス起動] → [OSぐるぐる 2-3秒] → [ウィンドウ表示]
After:  [プロセス起動] → [ダーク画面即表示] → [スケルトン] → [ファイル一覧]
```

## Test plan
- [x] tsc / vitest / Playwright 全通過
- [ ] 起動時にOSローディングカーソルが出ないことを確認