### PR TITLE
chore: bump version to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-filer",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "description": "Cross-platform desktop file manager built with Tauri 2 + React 19",
   "author": "win-chanma",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-filer"
-version = "0.2.4"
+version = "0.2.5"
 description = "Desktop File Manager"
 authors = ["win-chanma"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tauri Filer",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "com.win.tauri-filer",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
OSローディングカーソル排除 (#94) を含む v0.2.5