### PR TITLE
chore: bump version to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-filer",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Cross-platform desktop file manager built with Tauri 2 + React 19",
   "author": "win-chanma",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-filer"
-version = "0.2.1"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-filer"
-version = "0.2.5"
+version = "0.2.6"
 description = "Desktop File Manager"
 authors = ["win-chanma"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tauri Filer",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "com.win.tauri-filer",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
起動体験全面刷新 (#96) を含む v0.2.6