### PR TITLE
feat: OSクリップボード連携（Explorer↔コピペ）

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -459,6 +459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +898,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
@@ -4078,9 +4093,10 @@ dependencies = [
 
 [[package]]
 name = "tauri-filer"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
+ "clipboard-win",
  "dirs",
  "portable-pty",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,5 +29,8 @@ portable-pty = "0.8"
 tauri-plugin-updater = "2"
 ureq = { version = "2", features = ["json"] }
 
+[target.'cfg(windows)'.dependencies]
+clipboard-win = "5"
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/clipboard.rs
+++ b/src-tauri/src/commands/clipboard.rs
@@ -1,0 +1,79 @@
+#[cfg(windows)]
+mod platform {
+    use clipboard_win::{formats, raw, Clipboard, Getter, Setter};
+
+    pub fn read_files() -> Result<(Vec<String>, String), String> {
+        let _clip =
+            Clipboard::new_attempts(10).map_err(|e| format!("Clipboard open failed: {}", e))?;
+
+        let mut file_list = Vec::new();
+        if formats::FileList
+            .read_clipboard(&mut file_list)
+            .is_err()
+        {
+            return Ok((vec![], "copy".to_string()));
+        }
+
+        if file_list.is_empty() {
+            return Ok((vec![], "copy".to_string()));
+        }
+
+        // Read Preferred DropEffect to distinguish cut vs copy
+        let mode = if let Some(fmt) = raw::register_format("Preferred DropEffect") {
+            let mut buf = [0u8; 4];
+            if raw::get(fmt.get(), &mut buf).is_ok() {
+                let effect = u32::from_le_bytes(buf);
+                if effect & 2 != 0 {
+                    "cut"
+                } else {
+                    "copy"
+                }
+            } else {
+                "copy"
+            }
+        } else {
+            "copy"
+        };
+
+        Ok((file_list, mode.to_string()))
+    }
+
+    pub fn write_files(paths: &[String], mode: &str) -> Result<(), String> {
+        let _clip =
+            Clipboard::new_attempts(10).map_err(|e| format!("Clipboard open failed: {}", e))?;
+
+        let path_refs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+        formats::FileList
+            .write_clipboard(&path_refs)
+            .map_err(|e| format!("Write files failed: {}", e))?;
+
+        // Set Preferred DropEffect
+        if let Some(fmt) = raw::register_format("Preferred DropEffect") {
+            let effect: u32 = if mode == "cut" { 2 } else { 1 };
+            let _ = raw::set_without_clear(fmt.get(), &effect.to_le_bytes());
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+mod platform {
+    pub fn read_files() -> Result<(Vec<String>, String), String> {
+        Ok((vec![], "copy".to_string()))
+    }
+
+    pub fn write_files(_paths: &[String], _mode: &str) -> Result<(), String> {
+        Err("OS clipboard file operations not yet supported on this platform".to_string())
+    }
+}
+
+#[tauri::command]
+pub fn read_clipboard_files() -> Result<(Vec<String>, String), String> {
+    platform::read_files()
+}
+
+#[tauri::command]
+pub fn write_clipboard_files(paths: Vec<String>, mode: String) -> Result<(), String> {
+    platform::write_files(&paths, &mode)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,7 @@
+pub mod clipboard;
 pub mod fs_ops;
 pub mod updater;
 
+pub use clipboard::*;
 pub use fs_ops::*;
 pub use updater::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,8 @@ pub fn run() {
             terminal::terminal_resize,
             terminal::terminal_kill,
             check_update_version,
+            read_clipboard_files,
+            write_clipboard_files,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/commands/clipboard-commands.test.ts
+++ b/src/commands/clipboard-commands.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+
+const mockInvoke = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+import { readClipboardFiles, writeClipboardFiles } from "./clipboard-commands";
+
+describe("readClipboardFiles", () => {
+  it("OS クリップボードからファイルパスと mode を読み取る", async () => {
+    mockInvoke.mockResolvedValue([
+      ["C:\\Users\\test\\file.txt", "C:\\Users\\test\\image.png"],
+      "copy",
+    ]);
+
+    const result = await readClipboardFiles();
+    expect(result.paths).toEqual([
+      "C:\\Users\\test\\file.txt",
+      "C:\\Users\\test\\image.png",
+    ]);
+    expect(result.mode).toBe("copy");
+    expect(mockInvoke).toHaveBeenCalledWith("read_clipboard_files");
+  });
+
+  it("cut モードを正しく判定する", async () => {
+    mockInvoke.mockResolvedValue([["C:\\temp\\file.txt"], "cut"]);
+
+    const result = await readClipboardFiles();
+    expect(result.mode).toBe("cut");
+  });
+
+  it("クリップボードが空の場合は空配列を返す", async () => {
+    mockInvoke.mockResolvedValue([[], "copy"]);
+
+    const result = await readClipboardFiles();
+    expect(result.paths).toEqual([]);
+  });
+});
+
+describe("writeClipboardFiles", () => {
+  it("ファイルパスを OS クリップボードに書き込む", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+
+    await writeClipboardFiles(
+      ["C:\\Users\\test\\file.txt"],
+      "copy"
+    );
+    expect(mockInvoke).toHaveBeenCalledWith("write_clipboard_files", {
+      paths: ["C:\\Users\\test\\file.txt"],
+      mode: "copy",
+    });
+  });
+
+  it("cut モードで書き込む", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+
+    await writeClipboardFiles(
+      ["C:\\Users\\test\\file.txt"],
+      "cut"
+    );
+    expect(mockInvoke).toHaveBeenCalledWith("write_clipboard_files", {
+      paths: ["C:\\Users\\test\\file.txt"],
+      mode: "cut",
+    });
+  });
+});

--- a/src/commands/clipboard-commands.ts
+++ b/src/commands/clipboard-commands.ts
@@ -1,0 +1,22 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface OsClipboardFiles {
+  paths: string[];
+  mode: "copy" | "cut";
+}
+
+/** OS クリップボードからファイルパスを読み取り */
+export async function readClipboardFiles(): Promise<OsClipboardFiles> {
+  const [paths, mode] = await invoke<[string[], string]>(
+    "read_clipboard_files"
+  );
+  return { paths, mode: mode as "copy" | "cut" };
+}
+
+/** ファイルパスを OS クリップボードに書き込み */
+export async function writeClipboardFiles(
+  paths: string[],
+  mode: "copy" | "cut"
+): Promise<void> {
+  await invoke("write_clipboard_files", { paths, mode });
+}

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -5,6 +5,10 @@ import { useUIStore } from "../stores/ui-store";
 import { useClipboardStore } from "../stores/clipboard-store";
 import { useNavigation } from "./use-navigation";
 import { copyItems, moveItems, getHomeDir } from "../commands/fs-commands";
+import {
+  readClipboardFiles,
+  writeClipboardFiles,
+} from "../commands/clipboard-commands";
 
 interface ShortcutActions {
   onNewFolder: () => void;
@@ -42,14 +46,20 @@ export function useKeyboardShortcuts(actions: ShortcutActions) {
       if (ctrl && !shift && key === "c") {
         e.preventDefault();
         const paths = Array.from(selectedPaths);
-        if (paths.length > 0) useClipboardStore.getState().copy(paths);
+        if (paths.length > 0) {
+          useClipboardStore.getState().copy(paths);
+          writeClipboardFiles(paths, "copy").catch(() => {});
+        }
         return;
       }
       // Ctrl+X: Cut
       if (ctrl && !shift && key === "x") {
         e.preventDefault();
         const paths = Array.from(selectedPaths);
-        if (paths.length > 0) useClipboardStore.getState().cut(paths);
+        if (paths.length > 0) {
+          useClipboardStore.getState().cut(paths);
+          writeClipboardFiles(paths, "cut").catch(() => {});
+        }
         return;
       }
       // Ctrl+V: Paste
@@ -58,12 +68,27 @@ export function useKeyboardShortcuts(actions: ShortcutActions) {
         const tab = useTabStore.getState().tabs.find(
           (t) => t.id === useTabStore.getState().activeTabId
         );
-        if (!tab || clipboardPaths.length === 0) return;
+        if (!tab) return;
+
+        // Try OS clipboard first, fall back to internal
+        let pastePaths = clipboardPaths;
+        let pasteMode = clipboardMode;
         try {
-          if (clipboardMode === "copy") {
-            await copyItems(clipboardPaths, tab.path);
-          } else if (clipboardMode === "cut") {
-            await moveItems(clipboardPaths, tab.path);
+          const osClip = await readClipboardFiles();
+          if (osClip.paths.length > 0) {
+            pastePaths = osClip.paths;
+            pasteMode = osClip.mode;
+          }
+        } catch {
+          // OS clipboard unavailable, use internal
+        }
+
+        if (pastePaths.length === 0) return;
+        try {
+          if (pasteMode === "copy") {
+            await copyItems(pastePaths, tab.path);
+          } else if (pasteMode === "cut") {
+            await moveItems(pastePaths, tab.path);
             useClipboardStore.getState().clear();
           }
           refresh();

--- a/src/utils/context-menu-handlers.ts
+++ b/src/utils/context-menu-handlers.ts
@@ -1,4 +1,5 @@
 import type { FileEntry } from "../types";
+import { readClipboardFiles } from "../commands/clipboard-commands";
 
 export interface ContextMenuDeps {
   getActiveTabPath: () => string | null;
@@ -33,12 +34,27 @@ export function createContextMenuHandlers(deps: ContextMenuDeps) {
 
   const handlePaste = async () => {
     const tabPath = deps.getActiveTabPath();
-    if (!tabPath || deps.clipboardPaths.length === 0) return;
+    if (!tabPath) return;
+
+    // Try OS clipboard first, fall back to internal
+    let pastePaths = deps.clipboardPaths;
+    let pasteMode = deps.clipboardMode;
     try {
-      if (deps.clipboardMode === "copy") {
-        await deps.copyItems(deps.clipboardPaths, tabPath);
-      } else if (deps.clipboardMode === "cut") {
-        await deps.moveItems(deps.clipboardPaths, tabPath);
+      const osClip = await readClipboardFiles();
+      if (osClip.paths.length > 0) {
+        pastePaths = osClip.paths;
+        pasteMode = osClip.mode;
+      }
+    } catch {
+      // OS clipboard unavailable, use internal
+    }
+
+    if (pastePaths.length === 0) return;
+    try {
+      if (pasteMode === "copy") {
+        await deps.copyItems(pastePaths, tabPath);
+      } else if (pasteMode === "cut") {
+        await deps.moveItems(pastePaths, tabPath);
         deps.clipboardClear();
       }
       deps.refresh();


### PR DESCRIPTION
## Summary
- `clipboard-win` クレートで Windows ネイティブ CF_HDROP を読み書き
- Explorer でコピーしたファイルを Tauri Filer に Ctrl+V で貼り付け可能
- Tauri Filer でコピーしたファイルを Explorer に Ctrl+V で貼り付け可能
- Cut (Ctrl+X) / Copy (Ctrl+C) の区別を Preferred DropEffect で正しく判定
- コンテキストメニューの貼り付けも同様に OS クリップボード対応
- 非 Windows 環境ではフォールバック（内部クリップボード）

## 確認方法
1. Explorer でファイルを Ctrl+C → Tauri Filer で Ctrl+V → コピーされる
2. Tauri Filer でファイルを Ctrl+C → Explorer で Ctrl+V → コピーされる
3. Ctrl+X（切り取り）でも同様に動作する
4. コンテキストメニューの「貼り付け」でも同様

## Test plan
- [x] tsc / vitest 229テスト / Playwright 全通過
- [x] clipboard-commands.test.ts 新規5件追加
- [ ] 手動: Explorer ↔ Tauri Filer のコピー/切り取り/貼り付け確認

closes #100