### PR TITLE
feat: キーボードナビゲーション

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -82,6 +82,13 @@ export function AppLayout() {
     onRename: () => setRenameOpen(true),
     onDelete: () => setDeleteOpen(true),
     onSearch: () => setSearchOpen(true),
+    onFileOpen: (entry) => {
+      if (entry.isDir) {
+        navigateTo(entry.path);
+      } else {
+        openFile(entry.path).catch(console.error);
+      }
+    },
   });
 
   useMouseNavigation();

--- a/src/components/FileRow.tsx
+++ b/src/components/FileRow.tsx
@@ -8,6 +8,7 @@ import { getFileOpacity } from "../utils/file-opacity";
 interface FileRowProps {
   entry: FileEntry;
   selected: boolean;
+  focused?: boolean;
   isCut: boolean;
   onSelect: (e: React.MouseEvent) => void;
   onOpen: () => void;
@@ -20,6 +21,7 @@ interface FileRowProps {
 export const FileRow = memo(function FileRow({
   entry,
   selected,
+  focused,
   isCut,
   onSelect,
   onOpen,
@@ -40,7 +42,7 @@ export const FileRow = memo(function FileRow({
           : selected
             ? "bg-[var(--color-selection-bg)] text-[var(--color-text)]"
             : "text-[var(--color-text-dim)] hover:bg-white/5"
-      }${opacityClass ? ` ${opacityClass}` : ""}`}
+      }${focused && !selected ? " ring-1 ring-[var(--color-accent)]/50" : ""}${opacityClass ? ` ${opacityClass}` : ""}`}
       onClick={onSelect}
       onDoubleClick={onOpen}
       onContextMenu={(e) => {

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useRef, useEffect } from "react";
+import type { VirtuosoHandle } from "react-virtuoso";
 import { useTranslation } from "react-i18next";
 import { Virtuoso } from "react-virtuoso";
 import { useFileStore } from "../stores/file-store";
@@ -38,6 +39,8 @@ export function ListView({ onContextMenu, onFileOpen }: ListViewProps) {
   const clipboardPaths = useClipboardStore((s) => s.paths);
   const clipboardMode = useClipboardStore((s) => s.mode);
   const { handleDragStart, handleDragOver, handleDrop } = useDragDrop();
+  const focusedIndex = useFileStore((s) => s.focusedIndex);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
 
   const sortedEntries = useMemo(
     () => sortEntries(entries, sortConfig),
@@ -85,13 +88,23 @@ export function ListView({ onContextMenu, onFileOpen }: ListViewProps) {
     [setSortConfig]
   );
 
+  useEffect(() => {
+    if (focusedIndex >= 0 && virtuosoRef.current) {
+      virtuosoRef.current.scrollIntoView({ index: focusedIndex, behavior: "auto" });
+    }
+  }, [focusedIndex]);
+
   const itemContent = useCallback(
-    (_index: number, entry: FileEntry) => (
+    (index: number, entry: FileEntry) => (
       <FileRow
         entry={entry}
         selected={selectedPaths.has(entry.path)}
+        focused={index === focusedIndex}
         isCut={isCutPath(entry.path, clipboardPaths, clipboardMode)}
-        onSelect={(e) => handleSelect(entry, e)}
+        onSelect={(e) => {
+          handleSelect(entry, e);
+          useFileStore.getState().setFocusedIndex(index);
+        }}
         onOpen={() => handleOpen(entry)}
         onContextMenu={onContextMenu}
         onDragStart={(e) => handleDragStart(e, entry.path)}
@@ -106,7 +119,7 @@ export function ListView({ onContextMenu, onFileOpen }: ListViewProps) {
         }}
       />
     ),
-    [selectedPaths, clipboardPaths, clipboardMode, handleSelect, handleOpen, onContextMenu, handleDragStart, handleDragOver, handleDrop, loadDirectory]
+    [selectedPaths, focusedIndex, clipboardPaths, clipboardMode, handleSelect, handleOpen, onContextMenu, handleDragStart, handleDragOver, handleDrop, loadDirectory]
   );
 
   return (
@@ -135,6 +148,7 @@ export function ListView({ onContextMenu, onFileOpen }: ListViewProps) {
       <div className="flex-1 relative" onContextMenu={onContextMenu}>
         <div className="absolute inset-0 overflow-hidden">
           <Virtuoso
+            ref={virtuosoRef}
             data={visibleEntries}
             itemContent={itemContent}
           />

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -15,7 +15,11 @@ interface ShortcutActions {
   onRename: () => void;
   onDelete: () => void;
   onSearch: () => void;
+  onFileOpen: (entry: FileEntry) => void;
 }
+
+import type { FileEntry } from "../types";
+import { sortEntries } from "../utils/sort";
 
 export function useKeyboardShortcuts(actions: ShortcutActions) {
   const addTab = useTabStore((s) => s.addTab);
@@ -95,6 +99,69 @@ export function useKeyboardShortcuts(actions: ShortcutActions) {
         } catch (err) {
           console.error("Paste failed:", err);
         }
+        return;
+      }
+      // Arrow key navigation
+      if (!ctrl && !alt && (key === "arrowdown" || key === "arrowup" || key === "home" || key === "end")) {
+        e.preventDefault();
+        const { entries, sortConfig, focusedIndex } = useFileStore.getState();
+        const showHidden = useUIStore.getState().showHidden;
+        const sorted = sortEntries(entries, sortConfig);
+        const visible = showHidden ? sorted : sorted.filter((en) => !en.isHidden);
+        if (visible.length === 0) return;
+
+        let newIndex = focusedIndex;
+        if (key === "arrowdown") {
+          newIndex = focusedIndex < visible.length - 1 ? focusedIndex + 1 : focusedIndex;
+        } else if (key === "arrowup") {
+          newIndex = focusedIndex > 0 ? focusedIndex - 1 : 0;
+        } else if (key === "home") {
+          newIndex = 0;
+        } else if (key === "end") {
+          newIndex = visible.length - 1;
+        }
+
+        useFileStore.getState().setFocusedIndex(newIndex);
+        const target = visible[newIndex];
+        if (target) {
+          if (shift) {
+            // Shift: range from anchor to current (replace, not merge)
+            const { lastSelectedPath } = useFileStore.getState();
+            const anchorIdx = lastSelectedPath
+              ? visible.findIndex((en) => en.path === lastSelectedPath)
+              : 0;
+            const [from, to] = anchorIdx <= newIndex ? [anchorIdx, newIndex] : [newIndex, anchorIdx];
+            const range = visible.slice(from, to + 1).map((en) => en.path);
+            // Set selection without changing anchor (lastSelectedPath)
+            useFileStore.setState({ selectedPaths: new Set(range) });
+          } else {
+            useFileStore.getState().setSelectedPaths(new Set([target.path]));
+          }
+        }
+        return;
+      }
+      // Enter: Open selected
+      if (!ctrl && !alt && key === "enter") {
+        e.preventDefault();
+        const paths = Array.from(selectedPaths);
+        if (paths.length !== 1) return;
+        const { entries, sortConfig } = useFileStore.getState();
+        const sorted = sortEntries(entries, sortConfig);
+        const entry = sorted.find((en) => en.path === paths[0]);
+        if (entry) actions.onFileOpen(entry);
+        return;
+      }
+      // Escape: Clear selection
+      if (key === "escape") {
+        e.preventDefault();
+        useFileStore.getState().clearSelection();
+        useFileStore.getState().setFocusedIndex(-1);
+        return;
+      }
+      // Backspace: Go to parent directory
+      if (!ctrl && !alt && key === "backspace") {
+        e.preventDefault();
+        up();
         return;
       }
       // Delete

--- a/src/stores/file-store.ts
+++ b/src/stores/file-store.ts
@@ -8,6 +8,7 @@ interface FileStore {
   entries: FileEntry[];
   selectedPaths: Set<string>;
   lastSelectedPath: string | null;
+  focusedIndex: number;
   sortConfig: SortConfig;
   loading: boolean;
   error: string | null;
@@ -19,19 +20,21 @@ interface FileStore {
   selectAll: () => void;
   clearSelection: () => void;
   setSortConfig: (config: SortConfig) => void;
+  setFocusedIndex: (index: number) => void;
 }
 
 export const useFileStore = create<FileStore>((set, get) => ({
   entries: [],
   selectedPaths: new Set(),
   lastSelectedPath: null,
+  focusedIndex: -1,
   sortConfig: { key: "name", order: "asc" },
   loading: true,
   error: null,
 
   loadDirectory: async (path) => {
     const gen = ++loadGeneration;
-    set({ loading: true, error: null, selectedPaths: new Set(), lastSelectedPath: null });
+    set({ loading: true, error: null, selectedPaths: new Set(), lastSelectedPath: null, focusedIndex: -1 });
     try {
       const entries = await readDirectory(path);
       // 古いリクエストの結果は無視
@@ -82,6 +85,8 @@ export const useFileStore = create<FileStore>((set, get) => ({
   },
 
   clearSelection: () => set({ selectedPaths: new Set(), lastSelectedPath: null }),
+
+  setFocusedIndex: (index) => set({ focusedIndex: index }),
 
   setSortConfig: (config) => set({ sortConfig: config }),
 }));


### PR DESCRIPTION
## Summary
- ↑↓矢印キーでファイル一覧のフォーカス移動 + 選択
- Shift+↑↓で範囲選択（アンカーからカーソルまでの範囲を正確に追従）
- Home/End で先頭/末尾にジャンプ
- Enter で選択アイテムを開く
- Escape で選択解除
- Backspace で親ディレクトリに移動
- フォーカス行にリング表示、Virtuoso スクロール追従

## Test plan
- [x] tsc / vitest 229テスト / Playwright 全通過
- [x] dev で目視確認済み（Shift+範囲選択の修正含む）

closes #99