### PR TITLE
perf: 起動時WebView2キャッシュ自動クリア

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,24 @@ pub fn run() {
         .manage(PtyManager::new())
         .setup(|app| {
             use tauri::Manager;
+
+            // Clear WebView2 caches to maintain fast startup
+            if let Ok(data_dir) = app.path().app_local_data_dir() {
+                let webview_dir = data_dir.join("EBWebView");
+                let cache_dirs = [
+                    webview_dir.join("Default").join("Cache"),
+                    webview_dir.join("Default").join("Code Cache"),
+                    webview_dir.join("GrShaderCache"),
+                    webview_dir.join("ShaderCache"),
+                    webview_dir.join("GraphiteDawnCache"),
+                ];
+                for dir in &cache_dirs {
+                    if dir.is_dir() {
+                        let _ = std::fs::remove_dir_all(dir);
+                    }
+                }
+            }
+
             if let Some(window) = app.get_webview_window("main") {
                 if let Ok(icon) =
                     tauri::image::Image::from_bytes(include_bytes!("../icons/icon.png"))


### PR DESCRIPTION
## Summary
- 起動時に WebView2 の Cache / Code Cache / ShaderCache 等を自動削除
- キャッシュ肥大化（42MB+）による起動速度低下を防止
- localStorage（テーマ、言語、ブックマーク等のユーザー設定）は保持

## Test plan
- [x] tsc / vitest 229テスト / Playwright 全通過
- [ ] アプリを数回使用後、再起動で速度が維持されることを確認

closes #115