### PR TITLE
feat: 起動スプラッシュの ON/OFF 設定

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -138,11 +138,15 @@ export function AppLayout() {
   );
 
   useEffect(() => {
+    const showSplash = useUIStore.getState().showSplash;
     const dismissBoot = () => {
       const el = document.getElementById("boot-screen");
-      if (el) {
+      if (!el) return;
+      if (showSplash) {
         el.classList.add("fade-out");
         setTimeout(() => el.remove(), 300);
+      } else {
+        el.remove();
       }
     };
 

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -47,6 +47,8 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const setWindowTransparency = useUIStore((s) => s.setWindowTransparency);
   const windowOpacity = useUIStore((s) => s.windowOpacity);
   const setWindowOpacity = useUIStore((s) => s.setWindowOpacity);
+  const showSplash = useUIStore((s) => s.showSplash);
+  const setShowSplash = useUIStore((s) => s.setShowSplash);
   const dialogRef = useRef<HTMLDivElement>(null);
   const [activeSection, setActiveSection] = useState<SectionId>("display");
   const [themes, setThemes] = useState<Theme[]>([]);
@@ -233,6 +235,17 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                     </div>
                   </SettingRow>
                 )}
+
+                <SettingRow
+                  label={t("settings.showSplash")}
+                  description={t("settings.showSplashDesc")}
+                >
+                  <ToggleSwitch
+                    checked={showSplash}
+                    onChange={() => setShowSplash(!showSplash)}
+                    aria-label="Show boot splash"
+                  />
+                </SettingRow>
               </SettingsPane>
             )}
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -121,6 +121,10 @@ export const en = {
   "settings.windowOpacity": "Opacity",
   "settings.windowOpacityDesc": "Adjust the background opacity (30–100%)",
 
+  // Settings - Display (splash)
+  "settings.showSplash": "Boot splash",
+  "settings.showSplashDesc": "Show the boot animation on startup",
+
   // Settings - About
   "settings.sectionAbout": "About",
   "settings.aboutVersion": "Version",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -121,6 +121,10 @@ export const ja = {
   "settings.windowOpacity": "不透明度",
   "settings.windowOpacityDesc": "背景の不透明度を調整します（30〜100%）",
 
+  // Settings - Display (splash)
+  "settings.showSplash": "起動スプラッシュ",
+  "settings.showSplashDesc": "起動時のブートアニメーションを表示します",
+
   // Settings - About
   "settings.sectionAbout": "アプリについて",
   "settings.aboutVersion": "バージョン",

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -16,6 +16,7 @@ interface UISettings {
   terminalPadding: number;
   windowTransparency: boolean;
   windowOpacity: number;
+  showSplash: boolean;
 }
 
 interface UIStore extends UISettings {
@@ -30,6 +31,7 @@ interface UIStore extends UISettings {
   setTerminalPadding: (padding: number) => void;
   setWindowTransparency: (enabled: boolean) => void;
   setWindowOpacity: (opacity: number) => void;
+  setShowSplash: (show: boolean) => void;
 }
 
 const STORAGE_KEY = "tauri-filer-ui-settings";
@@ -59,6 +61,7 @@ const defaults: UISettings = {
   terminalPadding: 8,
   windowTransparency: false,
   windowOpacity: 80,
+  showSplash: true,
 };
 
 const initial: UISettings = { ...defaults, ...loadSettings() };
@@ -76,6 +79,7 @@ function getSettings(state: UIStore): UISettings {
     terminalPadding: state.terminalPadding,
     windowTransparency: state.windowTransparency,
     windowOpacity: state.windowOpacity,
+    showSplash: state.showSplash,
   };
 }
 
@@ -165,5 +169,9 @@ export const useUIStore = create<UIStore>((set, get) => ({
         s.windowTransparency ? opacity / 100 : undefined,
       );
     });
+  },
+  setShowSplash: (show) => {
+    set({ showSplash: show });
+    saveSettings(getSettings(get()));
   },
 }));


### PR DESCRIPTION
## Summary
- 設定 > 表示 に「起動スプラッシュ」トグル追加
- ON: ブートアニメーション → フェードアウト → メイン UI（デフォルト）
- OFF: 即座にメイン UI 表示（ブート画面スキップ）
- 設定は localStorage に永続化

## Test plan
- [x] tsc / vitest 229テスト / Playwright 全通過
- [ ] ON/OFF 切り替え後の再起動で動作確認

closes #116